### PR TITLE
feat: Add post-processing to clean LLM output for folder names

### DIFF
--- a/fileorg/ai/interface.py
+++ b/fileorg/ai/interface.py
@@ -238,7 +238,7 @@ class QualcommLLM(BaseLLM):
             "temperature": 0.1 
         }
 
-        with httpx.Client(timeout=180.0) as client:
+        with httpx.Client(timeout=600.0) as client:
             response = client.post(url, headers=headers, json=payload)
 
         llm_response = response.json()["choices"][-1]["message"]["content"]

--- a/fileorg/classifier/classifier.py
+++ b/fileorg/classifier/classifier.py
@@ -283,6 +283,12 @@ class CreateFolderNamer:
         """
         # 保留中文、英文大小寫與阿拉伯數字、空格，其餘全部移除（包括斜線）
         cleaned = re.sub(r'[^\u4e00-\u9fa5A-Za-z0-9\s]', '', text)
+        
+        # 移除 "foldername" 這個字眼，不分大小寫
+        cleaned = re.sub(r'foldername', '', cleaned, flags=re.IGNORECASE)
+        
+        return cleaned.strip()
+
         return cleaned.strip()
     
     def process_files(self, summaries_data: Dict[str, Any], base_output_dir: str = "./") -> Dict[str, List[Dict[str, str]]]:


### PR DESCRIPTION
clean_output function: This function now uses regular expressions to remove a wide range of invalid characters, preserving only Chinese and English letters, numbers, and spaces.

Specific string removal: It specifically removes the word "foldername" from the output, which the LLM sometimes incorrectly included in its response. This is done in a case-insensitive manner to handle variations like "Foldername" or "FOLDERNAME".