### PR TITLE
Add HTML and MHTML parsers with encoding detection and text extraction

### DIFF
--- a/fileorg/file_ops/file_parser/html_parser.py
+++ b/fileorg/file_ops/file_parser/html_parser.py
@@ -1,0 +1,47 @@
+# html_parser.py
+from pathlib import Path
+
+import chardet
+from bs4 import BeautifulSoup
+
+from fileorg.file_ops.ports import IParser, ParserOutput
+
+
+class HtmlParser(IParser):
+    """Parser for HTML (.html, .htm) files with encoding detection and text extraction."""
+
+    def _detect_encoding(self, file_path: Path) -> str:
+        """Detect file encoding for proper reading of multi-byte text."""
+        with open(file_path, "rb") as f:
+            raw = f.read(4096)  # 讀前4KB作為樣本
+        detected = chardet.detect(raw)
+        encoding = detected.get("encoding") or "utf-8"
+        encoding = encoding.lower()
+        if "big5" in encoding:
+            return "big5"
+        elif "gb" in encoding:
+            return "gb18030"
+        return encoding
+
+    def _truncate_content(self, content: str, char_limit: int) -> str:
+        """Truncate content if it exceeds character limit."""
+        if len(content) > char_limit:
+            return content[:char_limit]
+        return content
+
+    def parse(self, file_path: Path, char_limit: int) -> ParserOutput:
+        """Parse an HTML file, extract text content, handle encoding, and truncate if needed."""
+        try:
+            encoding = self._detect_encoding(file_path)
+            with open(file_path, "r", encoding=encoding, errors="ignore") as f:
+                html = f.read()
+
+            # 使用 BeautifulSoup 提取純文字
+            soup = BeautifulSoup(html, "html.parser")
+            text_content = soup.get_text(separator="\n", strip=True)
+
+            truncated_content = self._truncate_content(text_content, char_limit)
+
+            return ParserOutput(success=True, content=truncated_content, error="")
+        except Exception as e:
+            return ParserOutput(success=False, content="", error=str(e))

--- a/fileorg/file_ops/file_parser/mhtml_parser.py
+++ b/fileorg/file_ops/file_parser/mhtml_parser.py
@@ -1,0 +1,55 @@
+# mhtml_parser.py
+import email
+from pathlib import Path
+
+import chardet
+from bs4 import BeautifulSoup
+
+from fileorg.file_ops.ports import IParser, ParserOutput
+
+
+class MhtmlParser(IParser):
+    """Parser for MHTML (.mht, .mhtml) files with text extraction."""
+
+    def _detect_encoding(self, raw_bytes: bytes) -> str:
+        """Detect encoding for proper text decoding."""
+        detected = chardet.detect(raw_bytes[:4096])
+        encoding = detected.get("encoding") or "utf-8"
+        encoding = encoding.lower()
+        if "big5" in encoding:
+            return "big5"
+        elif "gb" in encoding:
+            return "gb18030"
+        return encoding
+
+    def _truncate_content(self, content: str, char_limit: int) -> str:
+        if len(content) > char_limit:
+            return content[:char_limit]
+        return content
+
+    def parse(self, file_path: Path, char_limit: int) -> ParserOutput:
+        try:
+            with open(file_path, "rb") as f:
+                raw_bytes = f.read()
+
+            # 用 email parser 處理 MHTML
+            msg = email.message_from_bytes(raw_bytes)
+            html_parts = []
+
+            for part in msg.walk():
+                content_type = part.get_content_type()
+                if content_type == "text/html":
+                    payload = part.get_payload(decode=True)
+                    encoding = self._detect_encoding(payload)
+                    html_text = payload.decode(encoding, errors="ignore")
+                    html_parts.append(html_text)
+
+            full_html = "\n".join(html_parts)
+            soup = BeautifulSoup(full_html, "html.parser")
+            text_content = soup.get_text(separator="\n", strip=True)
+            truncated_content = self._truncate_content(text_content, char_limit)
+
+            return ParserOutput(success=True, content=truncated_content, error="")
+
+        except Exception as e:
+            return ParserOutput(success=False, content="", error=str(e))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     # "tqdm>=4.65.0",
     # "charset-normalizer>=3.0.0",
     # "httpx>=0.28.1",
+    "beautifulsoup4>=4.14.2",
     "chardet>=5.2.0",
     "dotenv>=0.9.9",
     "loguru>=0.7.3",

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/e9/df2358efd7659577435e2177bfa69cba6c33216681af51a707193dec162a/beautifulsoup4-4.14.2.tar.gz", hash = "sha256:2a98ab9f944a11acee9cc848508ec28d9228abfd522ef0fad6a02a72e0ded69e", size = 625822, upload-time = "2025-09-29T10:05:42.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/fe/3aed5d0be4d404d12d36ab97e2f1791424d9ca39c2f754a6285d59a3b01d/beautifulsoup4-4.14.2-py3-none-any.whl", hash = "sha256:5ef6fa3a8cbece8488d66985560f97ed091e22bbc4e9c2338508a9d5de6d4515", size = 106392, upload-time = "2025-09-29T10:05:43.771Z" },
+]
+
+[[package]]
 name = "boolean-py"
 version = "5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -486,6 +499,7 @@ version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },
+    { name = "beautifulsoup4" },
     { name = "chardet" },
     { name = "dotenv" },
     { name = "loguru" },
@@ -508,6 +522,7 @@ dev = [
 requires-dist = [
     { name = "appdirs", specifier = ">=1.4.4" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.8.6" },
+    { name = "beautifulsoup4", specifier = ">=4.14.2" },
     { name = "chardet", specifier = ">=5.2.0" },
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=4.9.1" },
     { name = "dotenv", specifier = ">=0.9.9" },
@@ -1275,6 +1290,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Changes:

## HtmlParser

- Parses .html and .htm files.
- Detects file encoding using chardet.
- Extracts text content using BeautifulSoup.
- Truncates content if it exceeds the provided character limit.

## MhtmlParser

- Parses .mht and .mhtml files.
- Uses Python email module to extract text/html parts.
- Detects encoding and extracts text with BeautifulSoup.
- Truncates content according to the character limit.