### PR TITLE
Add support for additional file types and ensure parser client outputs are consistent

### DIFF
--- a/fileorg/file_ops/adapters/file_parser/excel_parser.py
+++ b/fileorg/file_ops/adapters/file_parser/excel_parser.py
@@ -1,0 +1,46 @@
+"""
+Excel (.xlsx) file parser for spreadsheet data extraction.
+
+Handles Excel files with automatic reading of all sheets.
+Extracts cell values as text for AI analysis, with truncation support.
+"""
+
+from pathlib import Path
+
+from openpyxl import load_workbook
+
+from fileorg.file_ops.ports.parser_ports import IParser, ParserOutput
+
+
+class ExcelParser(IParser):
+    """Parser for Excel .xlsx files with robust reading and truncation."""
+
+    def _truncate_content(self, content: str, char_limit: int) -> str:
+        """Truncate content if it exceeds character limit."""
+        if len(content) > char_limit:
+            return content[:char_limit]
+        return content
+
+    def parse(self, file_path: Path, char_limit: int) -> ParserOutput:
+        """Extract text from Excel file (.xlsx) with truncation."""
+        try:
+            wb = load_workbook(filename=file_path, read_only=True, data_only=True)
+            content = ""
+
+            for sheet in wb.worksheets:
+                for row in sheet.iter_rows(values_only=True):
+                    # Convert all cells to string and join with commas
+                    row_text = ",".join([str(cell) if cell is not None else "" for cell in row])
+                    content += row_text + "\n"
+
+                    # Stop if char_limit reached
+                    if len(content) >= char_limit:
+                        break
+                if len(content) >= char_limit:
+                    break
+
+            truncated_content = self._truncate_content(content, char_limit)
+            return ParserOutput(success=True, content=truncated_content, error="")
+
+        except Exception as e:
+            return ParserOutput(success=False, content="", error=f"Excel parsing failed: {e}")

--- a/fileorg/file_ops/adapters/parser_factory_adapter.py
+++ b/fileorg/file_ops/adapters/parser_factory_adapter.py
@@ -1,5 +1,7 @@
 from typing import Dict, List, Optional, Type
 
+from fileorg.file_ops.adapters.file_parser.csv_parser import CsvParser
+from fileorg.file_ops.adapters.file_parser.excel_parser import ExcelParser
 from fileorg.file_ops.adapters.file_parser.html_parser import HtmlParser
 from fileorg.file_ops.adapters.file_parser.mhtml_parser import MhtmlParser
 from fileorg.file_ops.adapters.file_parser.pdf_parser import PdfParser
@@ -23,11 +25,16 @@ class ParserFactoryAdapter(IParserFactory):
 
     def _register_default_parsers(self):
         self.register_parser(".txt", TxtParser)
-        self.register_parser(".pdf", PdfParser)
+        self.register_parser(".json", TxtParser)
+        self.register_parser(".md", TxtParser)
+        self.register_parser(".csv", CsvParser)
+        self.register_parser(".xlsx", ExcelParser)
         self.register_parser(".htm", HtmlParser)
+        self.register_parser(".html", HtmlParser)
         self.register_parser(".mhtml", MhtmlParser)
         self.register_parser(".pdf", PdfParser)
         self.register_parser(".doc", WordParser)
+        self.register_parser(".docx", WordParser)
         self.register_parser(".pptx", PptParser)
 
     def register_parser(self, extension: str, parser_class: Type[IParser]):

--- a/fileorg/file_ops/application/parser_client.py
+++ b/fileorg/file_ops/application/parser_client.py
@@ -6,15 +6,15 @@ Automatically loads appropriate parsers for different file types.
 """
 
 from pathlib import Path
-from typing import List
 
-from fileorg.file_ops.ports.parser_ports import IParserFactory, ParserOutput
+from fileorg.file_ops.ports.parser_ports import IParserFactory, MultiParserOutput, ParserOutput
+from fileorg.file_ops.ports.scanner_ports import ReportOutput
 
 
 class ParseFileClient:
     """Use case for parsing files using the injected parser factory."""
 
-    def __init__(self, parser_factory: IParserFactory, char_limit: int = 1000):
+    def __init__(self, parser_factory: IParserFactory, char_limit: int = 500):
         self.parser_factory = parser_factory
         self.char_limit = char_limit
 
@@ -29,5 +29,13 @@ class ParseFileClient:
 
         return parser.parse(path, self.char_limit)
 
-    def parse_multiple(self, file_paths: List[str | Path]) -> List[ParserOutput]:
-        return [self.parse(fp) for fp in file_paths]
+    def parse_multiple(self, report_out: ReportOutput) -> MultiParserOutput:
+        muti_parser_output = MultiParserOutput()
+        scanner_output = report_out.get("files", None)
+
+        for file_path_obj in scanner_output:
+            parse_result = self.parse(file_path_obj.get("path"))
+            if parse_result.error == "":
+                muti_parser_output.update({file_path_obj.get("path"): parse_result.content})
+
+        return muti_parser_output

--- a/fileorg/file_ops/application/parser_client.py
+++ b/fileorg/file_ops/application/parser_client.py
@@ -31,11 +31,15 @@ class ParseFileClient:
 
     def parse_multiple(self, report_out: ReportOutput) -> MultiParserOutput:
         muti_parser_output = MultiParserOutput()
-        scanner_output = report_out.get("files", None)
+        scanner_output = getattr(report_out, "files", None)
 
-        for file_path_obj in scanner_output:
-            parse_result = self.parse(file_path_obj.get("path"))
-            if parse_result.error == "":
-                muti_parser_output.update({file_path_obj.get("path"): parse_result.content})
+        if not scanner_output:
+            return muti_parser_output
+
+        for file_info in scanner_output:
+            parse_result = self.parse(file_info.path)
+
+            if getattr(parse_result, "success", False):
+                muti_parser_output[file_info.path] = parse_result.content
 
         return muti_parser_output

--- a/fileorg/file_ops/docs/parser_client.md
+++ b/fileorg/file_ops/docs/parser_client.md
@@ -1,0 +1,112 @@
+
+# Parser Client
+
+## **Overview**
+
+* `IParser`: Defines the interface that every file parser must implement (e.g., TXT, CSV, PDF parsers).
+* `IParserFactory`: Responsible for creating the correct parser instance based on file extension.
+* `ParserOutput`: Represents the result of parsing a single file.
+* `MultiParserOutput`: Represents the mapping between multiple file paths and their parsed contents.
+* `ParseFileClient`: Coordinates file parsing using the injected factory and handles multiple files.
+
+---
+
+### Core Data Classes
+
+#### `ParserOutput`
+
+Used for single-file parsing results.
+
+```python
+ParserOutput(
+    success=True,
+    content="Extracted text content...",
+    error=""
+)
+```
+
+* **success (bool)** – Whether parsing succeeded.
+* **content (str)** – Extracted text content.
+* **error (str)** – Error message if failed, otherwise empty.
+
+---
+
+#### `MultiParserOutput`
+
+Used when parsing multiple files in batch mode.
+This is a dictionary subclass where:
+- Key: Absolute file path (ScanOutput.path)
+- Value: Extracted text content (ParserOutput.content) for successful parses
+
+Only successful parses (ParserOutput.success=True) are included. Unsupported files or failed parses are not included.
+
+```python 
+from fileorg.file_ops.ports.parser_ports import MultiParserOutput
+
+# Initialize an empty MultiParserOutput
+multi_output = MultiParserOutput()
+
+# Add parsed contents
+multi_output["/path/to/file1.txt"] = "File 1 content..."
+multi_output["/path/to/file3.txt"] = "File 3 content..."
+
+# Access like a normal dictionary
+print(multi_output["/path/to/file1.txt"])  # 'File 1 content...'
+```
+
+It provides a consistent dictionary-style mapping of **file path → text content**.
+
+---
+
+### How the Client Works 
+
+The `ParseFileClient` class is responsible for coordinating parsing logic.
+
+```python
+from fileorg.file_ops.adapters.parser_factory_adapter import ParserFactoryAdapter
+from fileorg.file_ops.application.parser_client import ParseFileClient
+
+# 1. Create a factory that knows how to build parsers for different file types
+factory = ParserFactoryAdapter()
+
+# 2. Initialize the client with the factory and a character limit
+parser_file_client = ParseFileClient(parser_factory=factory, char_limit=10)
+
+# 3. Parse multiple files based on a scan report (ReportOutput)
+parser_results = parser_file_client.parse_multiple(report_out=scanner_result)
+
+print(parser_results)
+```
+
+---
+
+### **Expected Output**
+
+If some file types are **not supported** by your current `ParserFactoryAdapter`,
+the output will list them with error details.
+
+```python
+{
+    'tests/example_data/interview prepare/Ch4  Principles component analysis.pdf': 'Multivaria',
+    ...
+}
+```
+
+
+### **Example Flow Summary**
+
+```text
+ReportOutput (from FileScanner)
+       │
+       ▼
+ParseFileClient.parse_multiple()
+       │
+       ├── For each file:
+       │      ├── Detect extension
+       │      ├── Get parser from factory
+       │      ├── If unsupported → error result
+       │      └── If supported → ParserOutput(success=True, content=...)
+       │
+       ▼
+Returns MultiParserOutput or dict[file_path → ParserOutput.content]
+```

--- a/fileorg/file_ops/docs/scanner.md
+++ b/fileorg/file_ops/docs/scanner.md
@@ -1,0 +1,188 @@
+# IFileScanner adaptor
+
+* **Process Overview (Flow Description)**
+* **Ignore Pattern Configuration Explanation**
+
+You can paste this directly under your existing module-level docstring or in your README.
+
+---
+
+## 📘 Module Flow Description (File Scanner Module)
+
+This module is responsible for the **directory scanning workflow** within the FileOrg system.
+It recursively scans a target directory, collecting essential metadata (path, name, size) for each file while automatically excluding irrelevant or system-generated files according to ignore rules.
+
+### Workflow Summary
+
+1. **Initialization (`__init__`)**
+
+   * The user creates a `FileScanner(root_dir, ignore_patterns)` instance.
+   * The module validates whether the target directory exists and is a valid folder.
+   * Ignore patterns are configured (either user-provided or defaults).
+
+2. **Recursive Scanning (`scan` / `_scan`)**
+
+   * The scanning starts from `root_dir` and descends into subdirectories.
+   * For each item encountered:
+
+     * If it matches any ignore pattern (`_is_ignored()`), it is skipped.
+     * If it’s a directory, scanning continues recursively.
+     * If it’s a file, metadata such as path, name, and size are collected.
+
+3. **Report Generation (`generate_report`)**
+
+   * Aggregates scanning results into a structured summary that includes:
+
+     * Total file count (`file_count`)
+     * Total file size (`total_size`)
+     * Detailed file list (`files`)
+
+4. **Report Output (`save_report`)**
+
+   * Converts the generated report into JSON format and saves it to disk.
+   * Enables integration with other modules or external analysis tools.
+
+---
+
+## Ignore Pattern Configuration
+
+The module uses **glob-style pattern matching** to filter out files and directories that should be excluded during scanning.
+This is handled internally by the `_is_ignored()` method using the `fnmatch` library.
+
+### Default Ignore Rules (`DEFAULT_IGNORE_PATTERNS`)
+
+```python
+DEFAULT_IGNORE_PATTERNS = [
+    ".*",           # Hidden files and folders (e.g., .git, .env)
+    "__pycache__",  # Python bytecode cache
+    "node_modules", # Node.js dependency folder
+    "*.tmp",        # Temporary files
+    "*.log",        # Log files
+    "*.bak",        # Backup files
+    "Thumbs.db",    # Windows system cache
+    ".DS_Store",    # macOS system cache
+]
+```
+
+### Custom Ignore Rules
+
+Users can provide their own ignore list at initialization:
+
+```python
+custom_patterns = ["*.cache", "*.old", "temp_*"]
+scanner = FileScanner("/Users/leo/Documents", ignore_patterns=custom_patterns)
+```
+
+In this case, the scanner will use **only** the provided patterns and ignore the defaults.
+
+To extend (rather than replace) the default rules:
+
+```python
+scanner = FileScanner(
+    "/Users/leo/Documents",
+    ignore_patterns=FileScanner.DEFAULT_IGNORE_PATTERNS + ["*.bak", "test_*"]
+)
+```
+
+### Pattern Matching Logic
+
+* The comparison is made using `fnmatch.fnmatch(path.name, pattern)`.
+* Matching applies to **file/directory names only**, not the full path.
+* Examples:
+
+  * `"*.log"` → ignores all `.log` files.
+  * `"test_*"` → ignores files/folders starting with `test_`.
+  * `".*"` → ignores hidden files (those starting with a dot).
+
+---
+
+## Simplified Flow Diagram
+
+```text
+FileScanner()
+    │
+    ├── validate root_dir
+    │
+    ├── scan()
+    │     └── _scan(directory)
+    │           ├── skip ignored (via _is_ignored)
+    │           ├── if dir → recurse
+    │           └── if file → collect metadata
+    │
+    ├── generate_report()
+    │     └── aggregate total size / count
+    │
+    └── save_report()
+          └── write JSON report file
+```
+---
+
+# Usage Example
+
+The following example demonstrates how to initialize the `FileScanner`, perform a scan, generate a report, and export it as a JSON file.
+
+```python
+from fileorg.file_ops.scanner import FileScanner
+
+def main():
+    # 1. Define the target directory for scanning
+    target_dir = "/Users/leo/Documents/Projects"
+
+    # 2. (Optional) Define custom ignore patterns
+    custom_ignores = [
+        "*.tmp", "*.log", "build", "__pycache__", ".git", "*.bak"
+    ]
+
+    # 3. Initialize the scanner
+    scanner = FileScanner(root_dir=target_dir, ignore_patterns=custom_ignores)
+
+    # 4. Perform the scan and generate a report
+    report = scanner.generate_report()
+
+    # 5. Print basic report information
+    print("=== File Scan Report ===")
+    print(f"Root Directory : {report['root']}")
+    print(f"Total Files    : {report['file_count']}")
+    print(f"Total Size     : {report['total_size']} bytes")
+
+    # 6. Save the detailed report to a JSON file
+    output_file = "scan_report.json"
+    scanner.save_report(output_file)
+    print(f"\nReport saved to: {output_file}")
+
+if __name__ == "__main__":
+    main()
+```
+
+### Expected Output (Console)
+
+```
+=== File Scan Report ===
+Root Directory : /Users/leo/Documents/Projects
+Total Files    : 128
+Total Size     : 45,372,111 bytes
+
+Report saved to: scan_report.json
+```
+
+### Example Output File (`scan_report.json`)
+
+```json
+{
+    "root": "/Users/leo/Documents/Projects",
+    "file_count": 128,
+    "total_size": 45372111,
+    "files": [
+        {
+            "path": "/Users/leo/Documents/Projects/main.py",
+            "name": "main.py",
+            "size": 2048
+        },
+        {
+            "path": "/Users/leo/Documents/Projects/utils/helpers.py",
+            "name": "helpers.py",
+            "size": 3890
+        }
+    ]
+}
+```

--- a/fileorg/file_ops/ports/parser_ports.py
+++ b/fileorg/file_ops/ports/parser_ports.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 
 @dataclass
@@ -21,6 +21,31 @@ class ParserOutput:
     success: bool
     content: str
     error: str
+
+
+class MultiParserOutput(Dict[str, str]):
+    """
+    Represents a mapping from file paths to their parsed text content.
+
+    This class is a dictionary subclass where:
+    - **Key**: Absolute file path (from ScanOutput.path)
+    - **Value**: Extracted text content (from ParserOutput.content, only for successful parses)
+
+    It is intended to store the output of the file parsing stage in a format
+    suitable for downstream processing (e.g., feeding into an LLM).
+
+    Example:
+        >>> output = MultiParserOutput()
+        >>> output["/home/user/docs/report.pdf"] = "First quarter sales report..."
+        >>> output["/home/user/docs/report.pdf"]
+        'First quarter sales report...'
+
+    Notes:
+        - Only include files where parsing succeeded (ParserOutput.success == True).
+        - Can be used and accessed like a normal Python dictionary.
+    """
+
+    pass
 
 
 class IParser(ABC):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "dotenv>=0.9.9",
     "loguru>=0.7.3",
     "mammoth>=1.11.0",
+    "openpyxl>=3.1.5",
     "pdfplumber>=0.11.8",
     "python-docx>=1.2.0",
     "python-pptx>=1.0.2",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,7 +9,7 @@ from fileorg.file_ops.adapters.file_parser.txt_parser import TxtParser
 from fileorg.file_ops.adapters.file_parser.word_parser import WordParser
 from fileorg.file_ops.adapters.parser_factory_adapter import ParserFactoryAdapter
 from fileorg.file_ops.application.parser_client import ParseFileClient
-from fileorg.file_ops.ports.parser_ports import ParserOutput
+from fileorg.file_ops.ports.parser_ports import MultiParserOutput, ParserOutput
 
 
 class TestParserClient:
@@ -24,10 +24,21 @@ class TestParserClient:
         assert output.content[:5] == "Small"
 
     def test_parse_multiple(self):
-        outputs = self.parser_file_client.parse_multiple(file_paths=self.file_pat)
-        for result in outputs:
-            assert isinstance(result, ParserOutput)
-            assert result.success
+        report_out = {
+            "root": ".",
+            "file_count": 1,
+            "total_size": 67,
+            "files": [
+                {
+                    "path": "tests/example_data/interview prepare/Ch4  Principles component analysis.pdf",
+                    "name": "Ch4  Principles component analysis.pdf",
+                    "size": 1339552,
+                }
+            ],
+        }
+        outputs = self.parser_file_client.parse_multiple(report_out=report_out)
+        print(outputs)
+        assert isinstance(outputs, MultiParserOutput)
 
 
 class TestAdapterParser:

--- a/uv.lock
+++ b/uv.lock
@@ -547,6 +547,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -575,6 +584,7 @@ dependencies = [
     { name = "dotenv" },
     { name = "loguru" },
     { name = "mammoth" },
+    { name = "openpyxl" },
     { name = "pdfplumber" },
     { name = "python-docx" },
     { name = "python-pptx" },
@@ -605,6 +615,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "loguru", marker = "extra == 'dev'", specifier = ">=0.7.3" },
     { name = "mammoth", specifier = ">=1.11.0" },
+    { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pdfplumber", specifier = ">=0.11.8" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.9.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
@@ -1043,6 +1054,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #81

This PR includes the following updates:

* **Added file type support**: `.md`, `.xlsx`, `.json`, `.html`
* **Updated `ParseFileClient`** (`fileorg/file_ops/application/parser_client.py`)

  * Now properly handles I/O using `ScanOutput` as input
  * Returns `MultiParserOutput` for multiple file parsing results

### `MultiParserOutput` Example

```python
{
    "/home/user/docs/report.pdf": "第一季銷售報告...",
    "/home/user/docs/memo.docx": "會議紀錄: 討論產品規劃...",
    "/home/user/data/analysis.csv": "col1,col2\ndata1,data2\n..."
}
```