### PR TITLE
feat(cli): create a cli entry for fileorg service

### DIFF
--- a/fileorg/app/organizer.py
+++ b/fileorg/app/organizer.py
@@ -1,27 +1,77 @@
-import json
-from pathlib import Path
-
 from loguru import logger
 
+from fileorg.cli.progress_display import ProgressDisplay
 from fileorg.file_ops.adapters.parser_factory_adapter import ParserFactoryAdapter
 from fileorg.file_ops.adapters.scanner import FileScanner
 from fileorg.file_ops.application.parser_client import ParseFileClient
 from fileorg.file_ops.ports.parser_ports import MultiParserOutput
 from fileorg.file_ops.ports.scanner_ports import ReportOutput
 
-# 1. Create a factory that knows how to build parsers for different file types
-
 
 class FileOrganizer:
-    def __init__(self, char_limit: int = 500):
+    def __init__(self, args):
+        self.args = args
+        self.progress = ProgressDisplay()
         self.parser_factory = ParserFactoryAdapter()
         factory = ParserFactoryAdapter()
-        self.parser_file_client = ParseFileClient(parser_factory=factory, char_limit=char_limit)
+        self.parser_file_client = ParseFileClient(parser_factory=factory, char_limit=args.char_limit)
 
-    def start_organize(self, root_dir: Path):
+    def run(self):
+        if self.args.command == "organize":
+            self.run_organize()
+        elif self.args.command == "restore":
+            self.run_restore()
+
+    def run_organize(self):
+        preview = self.args.preview
+        root_dir = self.args.path
+        # === Phase 1: Scan ===
         logger.debug("start scanning")
+        self.progress.update("start scanning...")
         self.scanner = FileScanner(root_dir=root_dir)
+        logger.debug("generating scanning report")
+        self.progress.update("generating scanning report...")
         report_output: ReportOutput = self.scanner.generate_report()
-        logger.debug("start parse the file")
+
+        # === Phase 2: Parse ===
+        logger.debug("start parse the files")
+        self.progress.update("start parse the files...")
         multi_parser_output: MultiParserOutput = self.parser_file_client.parse_multiple(report_out=report_output)
-        logger.debug(f"multi_parser_output is \n{json.dumps(multi_parser_output)}")
+        logger.debug(f"multi_parser_output is \n{multi_parser_output}")
+
+        # === Phase 3: Classify ===
+        logger.debug("classifying files")
+        self.progress.update("Classifying files...")
+
+        # === Phase 4: Create Restoration Point ===
+        logger.debug("Creating restoration point...")
+        self.progress.update("Creating restoration point...")
+
+        # === Phase 5: Execute Organization (non-preview mode) ===
+        if not preview:
+            logger.debug("Moving files...")
+            self.progress.update("Moving files...")
+        else:
+            pass
+            # exec_result = ExecutionResult(success=False, preview=True)
+
+        # === Phase 6: Generate Report ===
+        logger.debug("Generating report...")
+        self.progress.update("Generating report...")
+
+        self.progress.done()
+
+    def run_restore(self):
+        manifest = self.args.manifest
+        self.progress.update(f"載入還原點: {manifest}")
+        # restoration = RestorationPoint(manifest_path=manifest)
+
+        # 模擬確認
+        confirm = input(f"是否確定還原 {manifest}? (y/N): ").strip().lower()
+        if confirm != "y":
+            print("❌ 已取消還原。")
+            return
+
+        self.progress.update("執行還原中...")
+        print("✅ 還原完成。")
+        self.progress.done()

--- a/fileorg/cli/argument_parser.py
+++ b/fileorg/cli/argument_parser.py
@@ -1,0 +1,22 @@
+# fileorg/cli/argument_parser.py
+import argparse
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="fileorg", description="AI File Organizer - Command Line Interface")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # === organize ===
+    organize_parser = subparsers.add_parser("organize", help="Organize files (scan → parse → classify → execute)")
+    organize_parser.add_argument("--path", "-p", required=True, metavar="DIR", help="Root directory to organize")
+    organize_parser.add_argument("--output", "-o", required=True, metavar="DIR", help="Output directory for organized files")
+    organize_parser.add_argument("--preview", "-d", action="store_true", help="Preview mode; does not actually move files")
+    organize_parser.add_argument("--model", default="default-llm", help="Specify the LLM model to use")
+    organize_parser.add_argument("--char-limit", type=int, default=500, metavar="N", help="Character limit for file content")
+
+    # === restore ===
+    restore_parser = subparsers.add_parser("restore", help="Restore previously organized files")
+    restore_parser.add_argument("--manifest", "-m", required=True, metavar="FILE", help="Path to the manifest file for restoration")
+
+    return parser

--- a/fileorg/cli/docs.md
+++ b/fileorg/cli/docs.md
@@ -1,0 +1,145 @@
+# FileOrg CLI Tool Documentation
+
+A command-line tool that can be installed in development mode or globally using `uv`, providing a convenient `fileorg` command for file organization.
+
+## Installation Methods
+
+### Development Mode (Editable Install)
+
+Install `fileorg` into your current virtual environment. Code changes will be immediately reflected without reinstallation, making this ideal for active development.
+
+```bash
+uv pip install -e .
+```
+
+**Usage:**
+```bash
+fileorg -p tests/example_data/entertainment --output tests --preview --char-limit 100
+```
+
+> **Note:** The executable will be located at `.venv/bin/fileorg`
+
+---
+
+### Global Installation (Production Use)
+
+Install as a standalone tool with an independent execution environment. The `fileorg` command will be available system-wide from `~/.local/bin`.
+
+```bash
+uv tool install .
+```
+
+**Verify installation:**
+```bash
+uv tool list
+# Expected output:
+# Installed tools:
+#   fileorg 0.1.0  /path/to/your/project
+```
+
+**Usage:**
+```bash
+fileorg -p tests/example_data/entertainment --output tests --preview --char-limit 100
+```
+
+> **Tip:** If you encounter a "No such file or directory" error, the virtual environment path from a previous installation may be invalid. Run `uv tool uninstall fileorg` and reinstall.
+
+---
+
+## Uninstallation
+
+### For Development Mode Installation:
+```bash
+uv pip uninstall fileorg
+```
+
+### For Global Installation:
+```bash
+uv tool uninstall fileorg
+```
+
+---
+
+## Development Testing (No Installation Required)
+
+For quick testing, debugging, or parameter validation without installation, run the module directly:
+
+```bash
+uv run -m fileorg.main -p tests/example_data/entertainment --output tests --preview --char-limit 100
+```
+
+> 💡 **Advantage:** This creates a temporary execution environment without installing anything, perfect for rapid development iterations.
+
+---
+
+## Troubleshooting
+
+### Error: `bash: .../fileorg: No such file or directory`
+
+**Cause:** A previous `uv tool install .` installation created a reference to an outdated `.venv` directory.
+
+**Solution:**
+```bash
+uv tool uninstall fileorg
+uv tool install . --force
+```
+
+---
+
+### Error: `uv pip uninstall fileorg` reports "not installed"
+
+**Cause:** The package name in `pyproject.toml` doesn't match the name you're attempting to uninstall.
+
+**Solution:**
+
+1. Check the `name` field in your `pyproject.toml`:
+   ```toml
+   [project]
+   name = "fileorg"
+   ```
+
+2. Use the exact name from the config:
+   ```bash
+   uv pip uninstall fileorg
+   ```
+   
+   If the actual name differs (e.g., `aprss`), use that name instead.
+
+---
+
+## Project Structure
+
+```
+.
+├── fileorg/
+│   ├── __init__.py
+│   └── main.py
+├── pyproject.toml
+└── README.md
+```
+
+### Example `pyproject.toml`
+
+```toml
+[project]
+name = "fileorg"
+version = "0.1.0"
+requires-python = ">=3.13"
+
+[project.scripts]
+fileorg = "fileorg.main:main"
+```
+
+---
+
+## Quick Start Example
+
+```bash
+fileorg -p tests/example_data/entertainment --output tests --preview --char-limit 100
+```
+
+This command:
+- Processes files from `tests/example_data/entertainment`
+- Outputs results to `tests`
+- Shows a preview before execution
+- Limits character processing to 100 characters

--- a/fileorg/cli/progress_display.py
+++ b/fileorg/cli/progress_display.py
@@ -1,0 +1,18 @@
+# fileorg/cli/progress_display.py
+import sys
+import time
+
+
+class ProgressDisplay:
+    def __init__(self):
+        self.last_message = None
+
+    def update(self, message: str):
+        sys.stdout.write(f"\r{message.ljust(60)}")
+        sys.stdout.flush()
+        self.last_message = message
+        time.sleep(0.2)  # Simulate delay (can be removed)
+
+    def done(self):
+        sys.stdout.write("\rAll tasks completed!\n")
+        sys.stdout.flush()

--- a/fileorg/main.py
+++ b/fileorg/main.py
@@ -1,14 +1,20 @@
 from dotenv import load_dotenv
+from loguru import logger
 
+# from fileorg.app.orchestrator import Orchestrator
 from fileorg.app.organizer import FileOrganizer
+from fileorg.cli.argument_parser import build_parser
 from fileorg.logger_config import setup_logger
 
 setup_logger(ENV=load_dotenv())
 
 
 def main():
-    fileorg = FileOrganizer(char_limit=100)
-    fileorg.start_organize(root_dir="tests/example_data/202510D")
+    parser = build_parser()
+    args = parser.parse_args()
+    logger.debug(f"args id {args}")
+    fileorg = FileOrganizer(args=args)
+    fileorg.run()
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ Repository = "https://github.com/leoliu5550/QualcommHackathon.git"
 Issues = "https://github.com/leoliu5550/QualcommHackathon/issues"
 
 [project.scripts]
-fileorg = "fileorg.cli:main"
+fileorg = "fileorg.main:main"
 
 [tool.setuptools.packages.find]
 include = ["fileorg*"]


### PR DESCRIPTION
**Changes:**

* Added `fileorg/cli/argument_parser.py`
  * Defines CLI entry commands (`organize`, `restore`) with argparse
  * Supports flags: `--path`, `--output`, `--preview`, `--char-limit`, `--manifest`
  
* Added `fileorg/cli/progress_display.py`
  * Provides lightweight progress display for terminal feedback
* Added `fileorg/app/organizer.py`
  * Implements main workflow: Scan → Parse → Classify → Execute
  * Integrates adapters (`FileScanner`, `ParserFactoryAdapter`, `ParseFileClient`)
  
* Added `fileorg/main.py` as CLI entrypoint
  * Loads environment and logging
  * Parses CLI arguments and executes `FileOrganizer`

**Example Usage:**

```bash
uv run -m fileorg.main organize -p tests/example_data/entertainment --output tests --preview --char-limit 100
```

**Notes:**

* Designed with clear separation between CLI (adapter) and application logic.
* Ready for future extensions (e.g., new commands or GUI/API adapters).
---
**Installation (Development Mode)**

Install the CLI tool locally using `uv` in editable mode.
This links your current source directory, so any code changes will be reflected immediately.

```bash
uv pip install -e .
```

**Usage:**

After installation, can run the CLI directly using the `fileorg` command:

```bash
fileorg organize -p tests/example_data/entertainment --output tests --preview --char-limit 100
```

**Explanation of options:**

* `--path, -p` → Root directory to organize
* `--output, -o` → Output directory for organized files
* `--preview` → Runs in dry-run mode (no files are moved)
* `--char-limit` → Limits number of characters parsed per file

