### PR TITLE
fix: enhance the stable in LLM inference

### DIFF
--- a/fileorg/app/file_coordinator.py
+++ b/fileorg/app/file_coordinator.py
@@ -12,6 +12,7 @@ from fileorg.llm_classifier.adapters.output_parsers.path_mapping_output_parser i
 from fileorg.llm_classifier.adapters.output_parsers.summary_output_parser import SummaryOutputParser
 from fileorg.llm_classifier.adapters.prompt_builders.classification_prompt_builder import ClassificationPromptBuilder
 from fileorg.llm_classifier.adapters.prompt_builders.summary_prompt_builder import SummaryPromptBuilder
+from fileorg.llm_classifier.adapters.sequential_file_id_mapper import SequentialFileIdMapper
 from fileorg.llm_classifier.adapters.template_loader import Jinja2TemplateLoader
 from fileorg.llm_classifier.application.file_classifier import FileClassifier
 from fileorg.llm_classifier.infrastructure.factories.provider_factory import ProviderFactory
@@ -88,15 +89,21 @@ class FileCoordinator:
             self.path_mapping_parser = PathMappingOutputParser()
             logger.debug("Output parsers initialized")
 
-            # 5. Initialize classifier with all dependencies
+            # 5. Initialize file ID mapper for stable file tracking
+            # Fixes Issue #112: Double-space filename bug
+            self.file_id_mapper = SequentialFileIdMapper(prefix="A", id_width=3)
+            logger.debug("File ID mapper initialized (fixes double-space filename bug)")
+
+            # 6. Initialize classifier with all dependencies
             self.classifier = FileClassifier(
                 llm_provider=self.llm_provider,
                 summary_prompt_builder=self.summary_builder,
                 summary_parser=self.summary_parser,
                 classification_prompt_builder=self.classification_builder,
                 classification_parser=self.path_mapping_parser,
+                file_id_mapper=self.file_id_mapper,
             )
-            logger.success("FileClassifier initialized successfully")
+            logger.success("FileClassifier initialized successfully with file ID mapping")
 
         except Exception as e:
             logger.error(f"Failed to initialize classifier: {e}")

--- a/fileorg/llm_classifier/adapters/__init__.py
+++ b/fileorg/llm_classifier/adapters/__init__.py
@@ -8,6 +8,7 @@ Organized by adapter type:
 - llm_providers: Hardware-specific LLM inference providers
 - output_parsers: LLM response parsing adapters
 - prompt_builders: Model-specific prompt construction adapters
+- sequential_file_id_mapper: File ID mapping for stable file tracking
 - template_loader: Template loading infrastructure
 - text_validator: Text validation infrastructure
 """
@@ -16,6 +17,7 @@ Organized by adapter type:
 from . import llm_providers, output_parsers, prompt_builders
 
 # Infrastructure adapters
+from .sequential_file_id_mapper import SequentialFileIdMapper
 from .template_loader import Jinja2TemplateLoader
 from .text_validator import BasicTextValidator
 
@@ -23,6 +25,7 @@ __all__ = [
     # Direct exports
     "BasicTextValidator",
     "Jinja2TemplateLoader",
+    "SequentialFileIdMapper",
     # Sub-packages
     "llm_providers",
     "output_parsers",

--- a/fileorg/llm_classifier/adapters/output_parsers/summary_output_parser.py
+++ b/fileorg/llm_classifier/adapters/output_parsers/summary_output_parser.py
@@ -52,13 +52,36 @@ class SummaryOutputParser(ISummaryParser):
             # Step 1: Extract JSON from response using shared utility
             json_data = extract_json_from_llm_output(text, strict=False)
 
+            # Debug logging for troubleshooting
+            logger.debug(f"Extracted JSON keys: {list(json_data.keys())}")
+            logger.debug(f"Looking for key: {file_path}")
+
             # Step 2: Extract keyword for the specified file_path
             if file_path and file_path not in json_data:
-                raise ValueError(f"File path '{file_path}' not found in LLM output")
+                # Log the actual LLM response for debugging
+                logger.error(f"LLM raw response (first 500 chars): {text[:500]}")
+                logger.error(f"Expected key '{file_path}' not found in JSON keys: {list(json_data.keys())}")
 
-            # Get the first file path if not specified
-            target_path = file_path if file_path else list(json_data.keys())[0]
-            keyword = json_data[target_path]
+                # Try to be more flexible ONLY when the expected key looks like a file ID
+                # This helps with file ID mapping but maintains strict behavior for file paths
+                is_file_id_format = (
+                    len(json_data) == 1
+                    and file_path
+                    and len(file_path) < 10  # File IDs are short (e.g., A001)
+                    and not ("/" in file_path or "\\" in file_path)  # Not a path
+                )
+
+                if is_file_id_format:
+                    actual_key = list(json_data.keys())[0]
+                    logger.warning(f"Using single available key '{actual_key}' instead of file ID '{file_path}'")
+                    target_path = actual_key
+                    keyword = json_data[actual_key]
+                else:
+                    raise ValueError(f"File path '{file_path}' not found in LLM output. Available keys: {list(json_data.keys())}")
+            else:
+                # Get the first file path if not specified
+                target_path = file_path if file_path else list(json_data.keys())[0]
+                keyword = json_data[target_path]
 
             # Step 3: Validate keyword format
             self._validate_keyword(keyword, target_path)

--- a/fileorg/llm_classifier/adapters/sequential_file_id_mapper.py
+++ b/fileorg/llm_classifier/adapters/sequential_file_id_mapper.py
@@ -1,0 +1,210 @@
+"""
+Sequential File ID Mapper - SOLID Implementation
+
+This module implements the IFileIdMapper interface using a simple sequential
+ID generation scheme (A001, A002, A003...).
+"""
+
+from typing import Dict, List, Optional
+
+from fileorg.llm_classifier.ports.interfaces import IFileIdMapper
+
+
+class SequentialFileIdMapper(IFileIdMapper):
+    """
+    Sequential file ID mapper using A001, A002, A003... format.
+
+    This implementation provides a simple, predictable ID scheme that:
+    - Is short and readable (better for LLM token efficiency)
+    - Is sortable (maintains file order)
+    - Has minimal collision risk within a single session
+    - Is deterministic for the same input order
+
+    Thread Safety: Not thread-safe. Create separate instances for concurrent use.
+
+    Usage:
+        # Initialize mapper
+        mapper = SequentialFileIdMapper()
+
+        # Create mappings for files
+        file_paths = [
+            "/Users/leo/Desktop/Ch7  Cluster analysis.pdf",  # Note: double space
+            "/Users/leo/Desktop/Ch8 Regression.pdf"
+        ]
+        id_to_path = mapper.create_mappings(file_paths)
+        # Result: {
+        #     "A001": "/Users/leo/Desktop/Ch7  Cluster analysis.pdf",
+        #     "A002": "/Users/leo/Desktop/Ch8 Regression.pdf"
+        # }
+
+        # Retrieve path by ID
+        path = mapper.get_path("A001")
+        # "/Users/leo/Desktop/Ch7  Cluster analysis.pdf"
+
+        # Retrieve ID by path
+        file_id = mapper.get_id("/Users/leo/Desktop/Ch7  Cluster analysis.pdf")
+        # "A001"
+
+        # Reset for new batch
+        mapper.reset()
+
+    Attributes:
+        _id_to_path: Internal mapping from file ID to file path
+        _path_to_id: Internal reverse mapping from file path to file ID
+        _counter: Current ID counter for sequential generation
+        _prefix: ID prefix (default: "A")
+        _id_width: Zero-padding width for ID numbers (default: 3)
+    """
+
+    def __init__(self, prefix: str = "A", id_width: int = 3):
+        """
+        Initialize the sequential file ID mapper.
+
+        Args:
+            prefix: Letter prefix for IDs (default: "A")
+            id_width: Number of digits in ID (default: 3 for A001-A999)
+
+        Raises:
+            ValueError: If prefix is not a single letter or id_width < 1
+        """
+        if not prefix.isalpha() or len(prefix) != 1:
+            raise ValueError(f"Prefix must be a single letter, got: {prefix}")
+        if id_width < 1:
+            raise ValueError(f"ID width must be >= 1, got: {id_width}")
+
+        self._prefix = prefix.upper()
+        self._id_width = id_width
+        self._counter = 0
+        self._id_to_path: Dict[str, str] = {}
+        self._path_to_id: Dict[str, str] = {}
+
+    def create_mappings(self, file_paths: List[str]) -> Dict[str, str]:
+        """
+        Create ID mappings for a list of file paths.
+
+        This method generates sequential IDs (A001, A002, ...) for each file path
+        in the order provided. Duplicate paths are rejected.
+
+        Args:
+            file_paths: List of absolute file paths to map
+
+        Returns:
+            Dictionary mapping file IDs to original paths
+            Example: {"A001": "/path/file1.txt", "A002": "/path/file2.txt"}
+
+        Raises:
+            ValueError: If file_paths is empty or contains duplicates
+        """
+        if not file_paths:
+            raise ValueError("file_paths cannot be empty")
+
+        # Check for duplicates
+        if len(file_paths) != len(set(file_paths)):
+            duplicates = [path for path in file_paths if file_paths.count(path) > 1]
+            raise ValueError(f"file_paths contains duplicate entries: {set(duplicates)}")
+
+        # Generate IDs sequentially
+        for file_path in file_paths:
+            file_id = self._generate_next_id()
+            self._id_to_path[file_id] = file_path
+            self._path_to_id[file_path] = file_id
+
+        return self._id_to_path.copy()
+
+    def get_path(self, file_id: str) -> Optional[str]:
+        """
+        Retrieve original file path for a given file ID.
+
+        Args:
+            file_id: The file identifier (e.g., "A001")
+
+        Returns:
+            Original file path if found, None otherwise
+
+        Examples:
+            >>> mapper = SequentialFileIdMapper()
+            >>> mapper.create_mappings(["/path/file.txt"])
+            >>> mapper.get_path("A001")
+            "/path/file.txt"
+            >>> mapper.get_path("A999")
+            None
+        """
+        return self._id_to_path.get(file_id)
+
+    def get_id(self, file_path: str) -> Optional[str]:
+        """
+        Retrieve file ID for a given file path.
+
+        Args:
+            file_path: The absolute file path
+
+        Returns:
+            File ID if found, None otherwise
+
+        Examples:
+            >>> mapper = SequentialFileIdMapper()
+            >>> mapper.create_mappings(["/path/file.txt"])
+            >>> mapper.get_id("/path/file.txt")
+            "A001"
+            >>> mapper.get_id("/nonexistent/path.txt")
+            None
+        """
+        return self._path_to_id.get(file_path)
+
+    def get_all_mappings(self) -> Dict[str, str]:
+        """
+        Get all current ID-to-path mappings.
+
+        Returns:
+            Dictionary of all current mappings {file_id: file_path}
+
+        Examples:
+            >>> mapper = SequentialFileIdMapper()
+            >>> mapper.create_mappings(["/path/file1.txt", "/path/file2.txt"])
+            >>> mapper.get_all_mappings()
+            {"A001": "/path/file1.txt", "A002": "/path/file2.txt"}
+        """
+        return self._id_to_path.copy()
+
+    def reset(self) -> None:
+        """
+        Clear all mappings and reset internal state.
+
+        This method is useful for processing new batches of files in the same
+        session without creating a new mapper instance.
+
+        Examples:
+            >>> mapper = SequentialFileIdMapper()
+            >>> mapper.create_mappings(["/path/file1.txt"])
+            >>> len(mapper.get_all_mappings())
+            1
+            >>> mapper.reset()
+            >>> len(mapper.get_all_mappings())
+            0
+        """
+        self._counter = 0
+        self._id_to_path.clear()
+        self._path_to_id.clear()
+
+    def _generate_next_id(self) -> str:
+        """
+        Generate the next sequential file ID.
+
+        Internal method for creating IDs in format: {prefix}{counter:0{width}d}
+        Example: A001, A002, A003...
+
+        Returns:
+            Next sequential file ID
+
+        Raises:
+            ValueError: If counter exceeds maximum value for the given width
+        """
+        max_value = 10**self._id_width - 1
+        if self._counter >= max_value:
+            raise ValueError(
+                f"Counter exceeded maximum value {max_value} for ID width {self._id_width}. Consider using a larger id_width or resetting the mapper."
+            )
+
+        self._counter += 1
+        file_id = f"{self._prefix}{self._counter:0{self._id_width}d}"
+        return file_id

--- a/fileorg/llm_classifier/application/file_classifier.py
+++ b/fileorg/llm_classifier/application/file_classifier.py
@@ -14,6 +14,7 @@ from loguru import logger
 
 from fileorg.llm_classifier.ports.interfaces import (
     IClassifierUseCase,
+    IFileIdMapper,
     ILLMProvider,
     IOutputParser,
     IPromptBuilder,
@@ -65,6 +66,7 @@ class FileClassifier(IClassifierUseCase):
         classification_prompt_builder: IPromptBuilder,
         classification_parser: IOutputParser,
         validator: Optional[ITextValidator] = None,
+        file_id_mapper: Optional[IFileIdMapper] = None,
     ):
         """
         Initialize file classifier with dependency injection.
@@ -83,6 +85,9 @@ class FileClassifier(IClassifierUseCase):
             classification_prompt_builder: Prompt builder for Stage 2 classification
             classification_parser: Parser for Stage 2 output (file mappings)
             validator: Optional text/path validator (ITextValidator)
+            file_id_mapper: Optional file ID mapper for stable file tracking (IFileIdMapper)
+                           When provided, uses file IDs instead of paths to prevent
+                           LLM normalization issues (e.g., double-space filenames)
 
         Note:
             All concrete adapters are injected from outside, not created here.
@@ -95,11 +100,13 @@ class FileClassifier(IClassifierUseCase):
         self.classification_prompt_builder = classification_prompt_builder
         self.classification_parser = classification_parser
         self.validator = validator
+        self.file_id_mapper = file_id_mapper
 
         logger.info(
             f"Initialized FileClassifier (two-stage) with "
             f"provider={llm_provider.__class__.__name__}, "
-            f"validator={'enabled' if validator else 'disabled'}"
+            f"validator={'enabled' if validator else 'disabled'}, "
+            f"file_id_mapper={'enabled' if file_id_mapper else 'disabled'}"
         )
 
     def classify(self, input_data: LLMInput) -> ClassificationOutput:
@@ -186,6 +193,11 @@ class FileClassifier(IClassifierUseCase):
             2. Generate keyword using llm_provider
             3. Parse keyword using summary_parser
 
+        If file_id_mapper is enabled:
+            - Uses stable file IDs (A001, A002, ...) instead of full paths
+            - Prevents LLM text normalization issues (e.g., double spaces)
+            - LLM sees {"A001": "content"} instead of {"path/with  spaces": "content"}
+
         Args:
             input_data: LLMInput containing file contents
                        Format: {"absolute_path": "content", ...}
@@ -212,13 +224,32 @@ class FileClassifier(IClassifierUseCase):
             raise ValueError(f"Input text must be valid JSON format: {e}") from e
 
         try:
+            # If file_id_mapper is enabled, create ID mappings upfront
+            id_to_path = None
+            if self.file_id_mapper:
+                file_paths = list(files.keys())
+                id_to_path = self.file_id_mapper.create_mappings(file_paths)
+                logger.debug(f"Created {len(id_to_path)} file ID mappings")
+
             # Process each file independently
             summaries = {}
             raw_responses = []
 
             for file_path, content in files.items():
-                # Build single-file input
-                single_file_input = json.dumps({file_path: content}, ensure_ascii=False)
+                # Determine what identifier to use for LLM
+                if self.file_id_mapper:
+                    # Use stable file ID instead of path
+                    file_id = self.file_id_mapper.get_id(file_path)
+                    if not file_id:
+                        raise ValueError(f"File ID not found for path: {file_path}")
+                    llm_identifier = file_id
+                    logger.debug(f"Using file ID '{file_id}' for path: {file_path}")
+                else:
+                    # Legacy path-based approach
+                    llm_identifier = file_path
+
+                # Build single-file input (using ID or path)
+                single_file_input = json.dumps({llm_identifier: content}, ensure_ascii=False)
 
                 # Build prompt for keyword extraction
                 # Note: The prompt builder decides the actual prompt format
@@ -237,12 +268,19 @@ class FileClassifier(IClassifierUseCase):
                 raw_responses.append(raw_response)
 
                 # Parse keyword into FileSummary
-                # Note: The parser decides how to extract the keyword
+                # Note: The parser receives the LLM identifier (ID or path)
                 summary = self.summary_parser.parse(
                     text=raw_response,
-                    file_path=file_path,
+                    file_path=llm_identifier,  # Use ID if mapper enabled, path otherwise
                     raw_length=len(raw_response),
                 )
+
+                # Update FileSummary with actual path and ID
+                if self.file_id_mapper:
+                    # Store actual path and file ID
+                    summary.file_path = file_path  # Restore original path
+                    summary.file_id = llm_identifier  # Store the file ID
+
                 summaries[file_path] = summary
 
                 # Use repr() to avoid UnicodeEncodeError on Windows console
@@ -272,6 +310,11 @@ class FileClassifier(IClassifierUseCase):
             2. Generate classification using llm_provider
             3. Parse into FileMapping objects using classification_parser
 
+        If file_id_mapper is enabled:
+            - Sends file IDs to LLM instead of paths
+            - Maps results back to original paths after parsing
+            - Includes file IDs in FileMapping objects
+
         Args:
             summaries: Dict mapping file paths to FileSummary objects
             max_tokens: Maximum tokens for LLM input
@@ -291,8 +334,21 @@ class FileClassifier(IClassifierUseCase):
         logger.debug("Stage 2: Classifying files based on keywords")
 
         try:
-            # Build keyword dict: {file_path: keyword}
-            keyword_dict = {path: summary.summary for path, summary in summaries.items()}
+            # Build keyword dict for LLM
+            # Use file IDs if mapper is enabled, otherwise use paths
+            if self.file_id_mapper:
+                # Use file IDs as keys: {file_id: keyword}
+                keyword_dict = {}
+                for path, summary in summaries.items():
+                    file_id = summary.file_id or self.file_id_mapper.get_id(path)
+                    if not file_id:
+                        raise ValueError(f"File ID not found for path: {path}")
+                    keyword_dict[file_id] = summary.summary
+                logger.debug(f"Using {len(keyword_dict)} file IDs for Stage 2")
+            else:
+                # Legacy: Use file paths as keys: {file_path: keyword}
+                keyword_dict = {path: summary.summary for path, summary in summaries.items()}
+
             keyword_json = json.dumps(keyword_dict, ensure_ascii=False)
 
             # Build classification prompt
@@ -315,7 +371,38 @@ class FileClassifier(IClassifierUseCase):
 
             # Parse into path mappings
             # Note: The parser decides how to extract and structure the results
-            path_mappings = self.classification_parser.parse(raw_response)
+            # Parser receives ID-based output if mapper is enabled
+            parsed_mappings = self.classification_parser.parse(raw_response)
+
+            # Convert ID-based mappings back to path-based mappings if needed
+            if self.file_id_mapper:
+                import os
+
+                path_mappings = {}
+                for identifier, mapping in parsed_mappings.items():
+                    # Identifier is a file ID, convert to original path
+                    original_path = self.file_id_mapper.get_path(identifier)
+                    if not original_path:
+                        raise ValueError(f"Original path not found for file ID: {identifier}")
+
+                    # Extract filename from original path
+                    filename = os.path.basename(original_path)
+
+                    # Reassemble new_relative_path with actual filename
+                    # Category is already normalized in the mapping
+                    category_normalized = mapping.category.replace(" ", "_")
+                    new_relative_path = f"{category_normalized}/{filename}"
+
+                    # Update mapping with correct path, file ID, and new path
+                    mapping.old_path = original_path
+                    mapping.new_relative_path = new_relative_path
+                    mapping.file_id = identifier
+                    path_mappings[original_path] = mapping
+
+                    logger.debug(f"Mapped {identifier} -> {original_path} -> {new_relative_path}")
+            else:
+                # Legacy: Mappings already use paths as keys
+                path_mappings = parsed_mappings
 
             logger.info(f"Stage 2 complete: {len(path_mappings)} files classified")
             return path_mappings, raw_response

--- a/fileorg/llm_classifier/ports/interfaces.py
+++ b/fileorg/llm_classifier/ports/interfaces.py
@@ -277,3 +277,93 @@ class ITemplateLoader(ABC):
             True if template exists and is accessible, False otherwise
         """
         pass
+
+
+class IFileIdMapper(ABC):
+    """
+    File ID mapping interface for converting file paths to stable identifiers.
+
+    This interface follows the Single Responsibility Principle (SRP) by focusing
+    solely on ID generation and path mapping. It solves the double-space filename
+    bug by providing stable IDs that aren't affected by LLM text normalization.
+
+    Usage:
+        # Create mapper and generate IDs for files
+        mapper = SequentialFileIdMapper()
+        file_paths = ["/path/file1.txt", "/path/file2.txt"]
+        id_map = mapper.create_mappings(file_paths)
+        # Result: {"A001": "/path/file1.txt", "A002": "/path/file2.txt"}
+
+        # Convert to ID-based representation for LLM
+        id_content_map = {file_id: content[path] for file_id, path in id_map.items()}
+
+        # Later, retrieve original path from ID
+        original_path = mapper.get_path("A001")  # "/path/file1.txt"
+
+    Implementations:
+        - SequentialFileIdMapper: Simple A001, A002... scheme (recommended)
+        - UUIDFileIdMapper: UUID-based IDs (for distributed systems)
+        - HashFileIdMapper: Content-hash based IDs (for deduplication)
+    """
+
+    @abstractmethod
+    def create_mappings(self, file_paths: List[str]) -> Dict[str, str]:
+        """
+        Create ID mappings for a list of file paths.
+
+        Args:
+            file_paths: List of absolute file paths to map
+
+        Returns:
+            Dictionary mapping file IDs to original paths
+            Example: {"A001": "/path/file1.txt", "A002": "/path/file2.txt"}
+
+        Raises:
+            ValueError: If file_paths is empty or contains duplicates
+        """
+        pass
+
+    @abstractmethod
+    def get_path(self, file_id: str) -> Optional[str]:
+        """
+        Retrieve original file path for a given file ID.
+
+        Args:
+            file_id: The file identifier (e.g., "A001")
+
+        Returns:
+            Original file path if found, None otherwise
+        """
+        pass
+
+    @abstractmethod
+    def get_id(self, file_path: str) -> Optional[str]:
+        """
+        Retrieve file ID for a given file path.
+
+        Args:
+            file_path: The absolute file path
+
+        Returns:
+            File ID if found, None otherwise
+        """
+        pass
+
+    @abstractmethod
+    def get_all_mappings(self) -> Dict[str, str]:
+        """
+        Get all current ID-to-path mappings.
+
+        Returns:
+            Dictionary of all current mappings {file_id: file_path}
+        """
+        pass
+
+    @abstractmethod
+    def reset(self) -> None:
+        """
+        Clear all mappings and reset internal state.
+
+        Useful for processing new batches of files in the same session.
+        """
+        pass

--- a/fileorg/llm_classifier/ports/models.py
+++ b/fileorg/llm_classifier/ports/models.py
@@ -32,22 +32,35 @@ class FileSummary:
     Single file summary result from Stage 1.
 
     Represents the summarization output for a single file.
+    Now supports file IDs to prevent path matching issues (e.g., double spaces).
 
     Usage:
+        # New ID-based approach (recommended)
         summary = FileSummary(
             file_path="C:/Desktop/report.pdf",
             summary="Q4 financial report with earnings data",
+            file_id="A001",
             metadata={"tokens": 150, "time_ms": 234}
+        )
+
+        # Legacy path-only approach (backward compatible)
+        summary = FileSummary(
+            file_path="C:/Desktop/report.pdf",
+            summary="Q4 financial report",
+            metadata={"tokens": 150}
         )
 
     Args:
         file_path: Absolute path of the file
         summary: Brief content summary (1-2 sentences)
+        file_id: Optional stable file identifier (e.g., "A001")
+                 Use this to avoid LLM path normalization issues
         metadata: Optional metadata (tokens, processing time, etc.)
     """
 
     file_path: str
     summary: str
+    file_id: Optional[str] = None
     metadata: Optional[Dict[str, Any]] = None
 
 
@@ -93,8 +106,20 @@ class FileMapping:
     Single file path mapping with metadata.
 
     Maps an old absolute path to a new organized relative path with categorization info.
+    Now supports file IDs for stable tracking through LLM processing.
 
     Usage:
+        # New ID-based approach (recommended)
+        mapping = FileMapping(
+            old_path="C:/Desktop/report.pdf",
+            new_relative_path="Financial_Reports/report.pdf",
+            category="Financial Reports",
+            summary="Q4 financial report",
+            reason="Contains financial data",
+            file_id="A001"
+        )
+
+        # Legacy path-only approach (backward compatible)
         mapping = FileMapping(
             old_path="C:/Desktop/report.pdf",
             new_relative_path="Financial_Reports/report.pdf",
@@ -109,6 +134,8 @@ class FileMapping:
         category: Original category name (spaces preserved)
         summary: Brief content summary (1-2 sentences)
         reason: Classification reasoning
+        file_id: Optional stable file identifier (e.g., "A001")
+                 Use this to track files through LLM processing stages
     """
 
     old_path: str
@@ -116,3 +143,4 @@ class FileMapping:
     category: str
     summary: str
     reason: str
+    file_id: Optional[str] = None

--- a/fileorg/llm_classifier/prompts/llama3b/v1/classification_system.jinja2
+++ b/fileorg/llm_classifier/prompts/llama3b/v1/classification_system.jinja2
@@ -1,38 +1,62 @@
-You are an intelligent file organization assistant. Based on the keywords extracted from files, classify them into meaningful categories and provide organized paths.
+You are a JSON-only file classification robot. You MUST follow these rules strictly:
 
-Requirements:
-1. Analyze the keywords to understand file content
-2. Create clear and descriptive category names
-3. Group similar files together based on keywords
-4. Provide a reason for each classification
-5. Ensure category names are concise (1-3 words)
-6. IMPORTANT: Use ENGLISH for category names and reasons
+CRITICAL RULES:
+1. Output ONLY valid JSON - no explanations, no commentary, no additional text
+2. NEVER modify the input keys - copy them exactly as provided
+3. The input keys might be file identifiers (like "A001") OR file paths
+4. Create clear, descriptive category names (1-3 words)
+5. Group similar files together based on keywords
+6. Use ENGLISH for all output
 
-Output Format:
-Respond ONLY with valid JSON in this exact format:
+KEY PRESERVATION RULE:
+Your output JSON must use the EXACT SAME KEYS from the input.
+Do not change, translate, or modify the keys in any way.
+
+OUTPUT FORMAT:
+For each key in the input, provide:
 {
-  "/absolute/path/to/file1.pdf": {
+  "<exact-key-from-input>": {
     "category": "Category Name",
-    "summary": "keyword from stage 1",
-    "reason": "Classification reasoning"
-  },
-  "/absolute/path/to/file2.docx": {
-    "category": "Another Category",
-    "summary": "keyword from stage 1",
-    "reason": "Classification reasoning"
+    "summary": "keyword from input",
+    "reason": "Brief classification reasoning"
   }
 }
 
-Example:
-{
-  "C:/Users/USER/Documents/report.pdf": {
-    "category": "Financial Reports",
-    "summary": "financial report",
-    "reason": "Based on keyword 'financial report', this is a financial document"
+CORRECT EXAMPLES:
+
+Input: {"A001": "clustering algorithms", "A002": "financial report"}
+Output: {
+  "A001": {
+    "category": "Machine Learning",
+    "summary": "clustering algorithms",
+    "reason": "ML algorithms and techniques"
   },
-  "C:/Users/USER/Desktop/meeting_notes.txt": {
+  "A002": {
+    "category": "Financial Documents",
+    "summary": "financial report",
+    "reason": "Financial reporting and analysis"
+  }
+}
+
+Input: {"/home/user/doc1.pdf": "meeting notes", "/home/user/doc2.txt": "recipe"}
+Output: {
+  "/home/user/doc1.pdf": {
     "category": "Meeting Notes",
     "summary": "meeting notes",
-    "reason": "Based on keyword 'meeting notes', this is meeting documentation"
+    "reason": "Meeting documentation"
+  },
+  "/home/user/doc2.txt": {
+    "category": "Recipes",
+    "summary": "recipe",
+    "reason": "Food and cooking"
   }
 }
+
+WRONG EXAMPLES (DO NOT DO THIS):
+
+Input: {"A001": "keyword"}
+Wrong: {"/path/to/file": {...}} (changed the key)
+Wrong: {"file_A001": {...}} (modified the key)
+Wrong: Here are the categories: {"A001": {...}} (added text)
+
+Remember: Copy all input keys exactly. Output pure JSON only.

--- a/fileorg/llm_classifier/prompts/llama3b/v1/classification_user.jinja2
+++ b/fileorg/llm_classifier/prompts/llama3b/v1/classification_user.jinja2
@@ -1,8 +1,11 @@
 {{ instruction }}
 
-Files with extracted keywords:
+Input JSON with file keywords (DO NOT modify the keys):
 ```json
 {{ file_summaries }}
 ```
 
-Please classify these files into categories based on their keywords.
+Task: Classify each file into a category based on its keyword.
+
+IMPORTANT: Your output must be valid JSON with the EXACT SAME KEYS from the input above.
+For each key, provide: {"<exact-key-from-input>": {"category": "...", "summary": "...", "reason": "..."}}

--- a/fileorg/llm_classifier/prompts/llama3b/v1/summary_system.jinja2
+++ b/fileorg/llm_classifier/prompts/llama3b/v1/summary_system.jinja2
@@ -1,22 +1,33 @@
-You are an intelligent file content analyzer. Your task is to extract 1-2 word keywords that best describe the content and purpose of each file.
+You are a JSON-only keyword extraction robot. You MUST follow these rules strictly:
 
-Requirements:
-1. Extract ONLY 1-2 words that best represent the file content
-2. Keywords should be descriptive and specific
-3. Use nouns or noun phrases
-4. Avoid generic words like "file", "document", "data"
-5. IMPORTANT: Use ENGLISH keywords only
+CRITICAL RULES:
+1. Output ONLY valid JSON - no explanations, no commentary, no additional text
+2. NEVER modify the input key - copy it exactly as provided
+3. Extract 1-2 word English keywords that describe the file content
+4. Use descriptive nouns or noun phrases
+5. Avoid generic words like "file", "document", "data"
 
-Output Format:
-Respond ONLY with valid JSON in this exact format:
-{
-  "/absolute/path/to/file1.pdf": "keyword",
-  "/absolute/path/to/file2.docx": "keyword phrase"
-}
+KEY PRESERVATION RULE:
+The input JSON has ONE key (either a file identifier like "A001" or a file path).
+Your output MUST use the EXACT SAME KEY - do not change, translate, or modify it.
 
-Example:
-{
-  "C:/Users/USER/Documents/report.pdf": "financial report",
-  "C:/Users/USER/Desktop/meeting_notes.txt": "meeting notes",
-  "C:/Users/USER/Downloads/invoice.xlsx": "invoice"
-}
+CORRECT EXAMPLES:
+
+Input: {"A001": "This document discusses machine learning clustering algorithms..."}
+Output: {"A001": "clustering algorithms"}
+
+Input: {"B042": "Annual financial report for Q4 2024..."}
+Output: {"B042": "financial report"}
+
+Input: {"/home/user/data.pdf": "Customer survey results and analysis..."}
+Output: {"/home/user/data.pdf": "survey analysis"}
+
+WRONG EXAMPLES (DO NOT DO THIS):
+
+Input: {"A001": "content"}
+Wrong: {"/path/to/file": "keyword"} (changed the key)
+Wrong: {"file_A001": "keyword"} (modified the key)
+Wrong: {"A001": "keyword", "explanation": "..."} (added extra fields)
+Wrong: Here is the result: {"A001": "keyword"} (added text)
+
+Remember: Copy the input key exactly. Output pure JSON only.

--- a/fileorg/llm_classifier/prompts/llama3b/v1/summary_user.jinja2
+++ b/fileorg/llm_classifier/prompts/llama3b/v1/summary_user.jinja2
@@ -1,8 +1,11 @@
 {{ instruction }}
 
-File to analyze:
+Input JSON (DO NOT modify the key):
 ```json
 {{ file_data }}
 ```
 
-Please extract 1-2 word keywords for this file based on its content.
+Task: Extract 1-2 word keywords describing the content.
+
+IMPORTANT: Your output must be valid JSON with the EXACT SAME KEY from the input above. Output format:
+{"<exact-key-from-input>": "your keywords here"}

--- a/fileorg/llm_classifier/tests/integration/test_double_space_filename_fix.py
+++ b/fileorg/llm_classifier/tests/integration/test_double_space_filename_fix.py
@@ -1,0 +1,389 @@
+"""
+This test verifies that the file ID mapping system correctly handles
+filenames with multiple consecutive spaces.
+"""
+
+import json
+
+import pytest
+
+from fileorg.llm_classifier.adapters.output_parsers import (
+    PathMappingOutputParser,
+    SummaryOutputParser,
+)
+from fileorg.llm_classifier.adapters.prompt_builders import (
+    ClassificationPromptBuilder,
+    SummaryPromptBuilder,
+)
+from fileorg.llm_classifier.adapters.sequential_file_id_mapper import SequentialFileIdMapper
+from fileorg.llm_classifier.adapters.template_loader import Jinja2TemplateLoader
+from fileorg.llm_classifier.application.file_classifier import FileClassifier
+from fileorg.llm_classifier.ports.models import LLMInput
+
+
+class MockLLMProviderForDoubleSpace:
+    """
+    Mock LLM provider that simulates the double-space normalization issue.
+
+    This provider mimics the behavior where LLMs collapse multiple spaces
+    into single spaces in their output.
+    """
+
+    def __init__(self):
+        self.call_count = 0
+        self.stage1_responses = []
+        self.stage2_response = None
+        self.stage1_file_ids = set()  # Track which file IDs we've seen in Stage 1
+
+    def generate(self, messages, max_tokens=32768):
+        """
+        Generate mock responses.
+
+        Stage 1: Returns file IDs (A001, A002, etc.) with keywords
+        Stage 2: Returns file IDs with classification
+        """
+        self.call_count += 1
+
+        # Extract the input from messages
+        user_message = next((m for m in messages if m["role"] == "user"), None)
+        if not user_message:
+            return "{}"
+
+        content = user_message["content"]
+
+        # Parse JSON from content
+        try:
+            # Extract JSON from markdown if present
+            if "```json" in content:
+                json_start = content.find("```json") + 7
+                json_end = content.find("```", json_start)
+                json_str = content[json_start:json_end].strip()
+            elif "```" in content:
+                json_start = content.find("```") + 3
+                json_end = content.find("```", json_start)
+                json_str = content[json_start:json_end].strip()
+            else:
+                # Try to find JSON object in content
+                json_start = content.find("{")
+                json_end = content.rfind("}") + 1
+                json_str = content[json_start:json_end]
+
+            data = json.loads(json_str)
+
+            # Check if this is Stage 1 or Stage 2
+            # Strategy:
+            # 1. If we've seen this file ID before → Stage 2
+            # 2. If multiple keys → Stage 2 (classifying all files together)
+            # 3. Otherwise → Stage 1 (first time seeing this single file)
+            keys = list(data.keys())
+            first_key = keys[0]
+
+            if first_key in self.stage1_file_ids:
+                # Already processed in Stage 1, must be Stage 2
+                is_stage1 = False
+            elif len(keys) > 1:
+                # Multiple files = Stage 2 classification
+                is_stage1 = False
+            else:
+                # Single file, not seen before = Stage 1
+                is_stage1 = True
+
+            if is_stage1:
+                # Stage 1: Single file keyword extraction
+                file_id = keys[0]
+
+                # Map file IDs to keywords based on content
+                content = data[file_id]
+
+                if "Cluster" in content or "clustering" in content:
+                    keyword = "Cluster Analysis"
+                elif "Regression" in content or "regression" in content:
+                    keyword = "Regression Techniques"
+                elif "Recipe" in content or "cake" in content.lower():
+                    keyword = "Chocolate Cake Recipe"
+                elif "Budget" in content or "budget" in content.lower():
+                    keyword = "Project Budget"
+                elif "with  spaces" in file_id or "spaces" in content:
+                    keyword = "Document"
+                else:
+                    keyword = "General Document"
+
+                response = json.dumps({file_id: keyword}, ensure_ascii=False)
+                self.stage1_responses.append(response)
+                self.stage1_file_ids.add(file_id)  # Track that we've processed this file ID
+                return response
+
+            else:
+                # Stage 2: Classification of all files
+                # LLM returns file IDs with classification
+                classifications = {}
+
+                for file_id, keyword in data.items():
+                    # Ensure keyword is a string
+                    if not isinstance(keyword, str):
+                        keyword = str(keyword)
+
+                    if "Cluster" in keyword or "Regression" in keyword or "Machine Learning" in keyword:
+                        classifications[file_id] = {
+                            "category": "Machine Learning",
+                            "summary": keyword,
+                            "reason": "Educational content about ML algorithms",
+                        }
+                    elif "Recipe" in keyword or "Cake" in keyword or "Chocolate" in keyword:
+                        classifications[file_id] = {"category": "Recipes", "summary": keyword, "reason": "Food recipe document"}
+                    elif "Budget" in keyword or "Project" in keyword or "Financial" in keyword:
+                        classifications[file_id] = {"category": "Financial Documents", "summary": keyword, "reason": "Budget and financial planning"}
+                    elif "Document" in keyword:
+                        classifications[file_id] = {"category": "General Documents", "summary": keyword, "reason": "General document"}
+                    else:
+                        classifications[file_id] = {"category": "General", "summary": keyword, "reason": "General document"}
+
+                response = json.dumps(classifications, ensure_ascii=False)
+                self.stage2_response = response
+                return response
+
+        except Exception as e:
+            print(f"Mock LLM error: {e}")
+            import traceback
+
+            traceback.print_exc()
+            return "{}"
+
+    def get_device_info(self):
+        return "MockProvider for Double-Space Test"
+
+
+@pytest.fixture
+def template_loader():
+    """Create template loader."""
+    return Jinja2TemplateLoader()
+
+
+@pytest.fixture
+def mock_llm_provider():
+    """Create mock LLM provider."""
+    return MockLLMProviderForDoubleSpace()
+
+
+@pytest.fixture
+def file_id_mapper():
+    """Create file ID mapper."""
+    return SequentialFileIdMapper(prefix="A", id_width=3)
+
+
+@pytest.fixture
+def file_classifier(template_loader, mock_llm_provider, file_id_mapper):
+    """Create FileClassifier with file ID mapping enabled."""
+    summary_builder = SummaryPromptBuilder(template_loader=template_loader, provider="llama3b", version="v1")
+    classification_builder = ClassificationPromptBuilder(template_loader=template_loader, provider="llama3b", version="v1")
+    summary_parser = SummaryOutputParser()
+    path_mapping_parser = PathMappingOutputParser()
+
+    return FileClassifier(
+        llm_provider=mock_llm_provider,
+        summary_prompt_builder=summary_builder,
+        summary_parser=summary_parser,
+        classification_prompt_builder=classification_builder,
+        classification_parser=path_mapping_parser,
+        file_id_mapper=file_id_mapper,  # Enable file ID mapping
+    )
+
+
+def test_double_space_filename_handling(file_classifier, mock_llm_provider):
+    """
+    Test that files with double spaces in filenames are correctly handled.
+
+    This is the main test for Issue #112.
+    """
+    # Input: Files with double spaces in filenames
+    files = {
+        "C:/Users/leo/Desktop/Ch7  Cluster analysis.txt": "Chapter about clustering algorithms",
+        "C:/Users/leo/Desktop/Ch8  Regression techniques.txt": "Chapter about regression methods",
+        "C:/Users/leo/Desktop/Recipe  Chocolate cake.txt": "Delicious chocolate cake recipe",
+        "C:/Users/leo/Desktop/Project  Budget 2024.txt": "Annual project budget document",
+    }
+
+    input_text = json.dumps(files, ensure_ascii=False)
+    llm_input = LLMInput(text=input_text, max_tokens=150000)
+
+    # Execute classification
+    result = file_classifier.classify(llm_input)
+
+    # Verify all files were processed
+    assert len(result.path_mappings) == 4, f"Expected 4 files, got {len(result.path_mappings)}"
+
+    # Verify original paths are preserved (with double spaces)
+    expected_paths = [
+        "C:/Users/leo/Desktop/Ch7  Cluster analysis.txt",
+        "C:/Users/leo/Desktop/Ch8  Regression techniques.txt",
+        "C:/Users/leo/Desktop/Recipe  Chocolate cake.txt",
+        "C:/Users/leo/Desktop/Project  Budget 2024.txt",
+    ]
+
+    for path in expected_paths:
+        assert path in result.path_mappings, f"Path '{path}' not found in results"
+        mapping = result.path_mappings[path]
+
+        # Verify the mapping has correct structure
+        assert mapping.old_path == path
+        assert mapping.file_id is not None, f"File ID not set for {path}"
+        assert mapping.new_relative_path is not None
+        assert mapping.category is not None
+        assert mapping.summary is not None
+        assert mapping.reason is not None
+
+        print(f"[OK] {path}")
+        print(f"  File ID: {mapping.file_id}")
+        print(f"  Category: {mapping.category}")
+        print(f"  New path: {mapping.new_relative_path}")
+        print()
+
+    # Verify filenames are correctly extracted (not using IDs)
+    ch7_mapping = result.path_mappings["C:/Users/leo/Desktop/Ch7  Cluster analysis.txt"]
+    assert "Ch7  Cluster analysis.txt" in ch7_mapping.new_relative_path, f"Filename not preserved correctly: {ch7_mapping.new_relative_path}"
+
+    # Verify Stage 1 and Stage 2 were called
+    # Stage 1: 4 files = 4 calls
+    # Stage 2: 1 call for classification
+    assert mock_llm_provider.call_count == 5, f"Expected 5 LLM calls (4 Stage 1 + 1 Stage 2), got {mock_llm_provider.call_count}"
+
+    print(f"[PASS] All tests passed! Mock LLM was called {mock_llm_provider.call_count} times.")
+
+
+def test_file_id_mapping_with_stage1_responses(file_classifier, mock_llm_provider):
+    """Verify that Stage 1 responses use file IDs instead of paths."""
+    files = {
+        "C:/test/file  with  spaces.txt": "Content with multiple spaces in filename",
+    }
+
+    input_text = json.dumps(files, ensure_ascii=False)
+    llm_input = LLMInput(text=input_text, max_tokens=150000)
+
+    # Execute classification
+    file_classifier.classify(llm_input)
+
+    # Check that Stage 1 response contains file ID (A001) not path
+    stage1_response = mock_llm_provider.stage1_responses[0]
+    assert "A001" in stage1_response, f"Expected file ID 'A001' in response: {stage1_response}"
+    assert "file  with  spaces" not in stage1_response, f"Path should not be in Stage 1 response: {stage1_response}"
+
+    print("[PASS] Stage 1 correctly uses file IDs")
+    print(f"   Response: {stage1_response}")
+
+
+def test_file_id_mapping_with_stage2_responses(file_classifier, mock_llm_provider):
+    """Verify that Stage 2 responses use file IDs instead of paths."""
+    files = {
+        "C:/test1/file  one.txt": "First file",
+        "C:/test2/file  two.txt": "Second file",
+    }
+
+    input_text = json.dumps(files, ensure_ascii=False)
+    llm_input = LLMInput(text=input_text, max_tokens=150000)
+
+    # Execute classification
+    file_classifier.classify(llm_input)
+
+    # Check that Stage 2 response contains file IDs not paths
+    stage2_response = mock_llm_provider.stage2_response
+    assert "A001" in stage2_response, f"Expected file ID 'A001' in Stage 2: {stage2_response}"
+    assert "A002" in stage2_response, f"Expected file ID 'A002' in Stage 2: {stage2_response}"
+    assert "file  one" not in stage2_response, f"Paths should not be in Stage 2 response: {stage2_response}"
+
+    print("[PASS] Stage 2 correctly uses file IDs")
+    print(f"   Response: {stage2_response}")
+
+
+def test_backward_compatibility_without_file_id_mapper():
+    """Test that system still works without file ID mapper (backward compatibility)."""
+
+    class SimpleMockLLM:
+        """Simple mock that returns paths directly (no file IDs)."""
+
+        def __init__(self):
+            self.call_count = 0
+
+        def generate(self, messages, max_tokens=32768):
+            self.call_count += 1
+
+            # Parse input
+            user_message = next((m for m in messages if m["role"] == "user"), None)
+            if not user_message:
+                return "{}"
+
+            content = user_message["content"]
+
+            # Extract JSON from markdown code blocks or plain text
+            try:
+                # Try to extract from markdown code block first
+                if "```json" in content:
+                    json_start = content.find("```json") + 7
+                    json_end = content.find("```", json_start)
+                    json_str = content[json_start:json_end].strip()
+                elif "```" in content:
+                    json_start = content.find("```") + 3
+                    json_end = content.find("```", json_start)
+                    json_str = content[json_start:json_end].strip()
+                else:
+                    # Find JSON object in content
+                    json_start = content.find("{")
+                    json_end = content.rfind("}") + 1
+                    if json_start == -1 or json_end == 0:
+                        return "{}"
+                    json_str = content[json_start:json_end]
+
+                data = json.loads(json_str)
+
+                keys = list(data.keys())
+                first_value = str(data[keys[0]])
+
+                # Check if Stage 1 or Stage 2 based on value length
+                is_stage1 = len(first_value) > 20
+
+                if is_stage1:
+                    # Stage 1: Return path with keyword
+                    path = keys[0]
+                    return json.dumps({path: "General Document"}, ensure_ascii=False)
+                else:
+                    # Stage 2: Return classification
+                    result = {}
+                    for path in data.keys():
+                        result[path] = {"category": "General", "summary": "General Document", "reason": "General file"}
+                    return json.dumps(result, ensure_ascii=False)
+            except Exception as e:
+                print(f"SimpleMockLLM error: {e}")
+                import traceback
+
+                traceback.print_exc()
+                return "{}"
+
+    template_loader = Jinja2TemplateLoader()
+    mock_llm = SimpleMockLLM()
+
+    # Create classifier WITHOUT file_id_mapper
+    classifier = FileClassifier(
+        llm_provider=mock_llm,
+        summary_prompt_builder=SummaryPromptBuilder(template_loader, "llama3b", "v1"),
+        summary_parser=SummaryOutputParser(),
+        classification_prompt_builder=ClassificationPromptBuilder(template_loader, "llama3b", "v1"),
+        classification_parser=PathMappingOutputParser(),
+        file_id_mapper=None,  # No file ID mapper
+    )
+
+    # Note: This would fail with actual double-space files due to LLM normalization,
+    # but with our mock it should work since mock doesn't normalize
+    files = {
+        "C:/test/normal_file.txt": "Normal filename content",
+    }
+
+    input_text = json.dumps(files, ensure_ascii=False)
+    llm_input = LLMInput(text=input_text, max_tokens=150000)
+
+    result = classifier.classify(llm_input)
+
+    assert len(result.path_mappings) == 1
+    # File ID should not be set when mapper is not used
+    mapping = result.path_mappings["C:/test/normal_file.txt"]
+    assert mapping.file_id is None, "File ID should be None in legacy mode"
+
+    print("[PASS] Backward compatibility test passed (no file_id_mapper)")

--- a/fileorg/llm_classifier/tests/unit/adapters/test_sequential_file_id_mapper.py
+++ b/fileorg/llm_classifier/tests/unit/adapters/test_sequential_file_id_mapper.py
@@ -1,0 +1,308 @@
+"""
+Unit tests for SequentialFileIdMapper.
+"""
+
+import pytest
+
+from fileorg.llm_classifier.adapters.sequential_file_id_mapper import SequentialFileIdMapper
+
+
+class TestSequentialFileIdMapper:
+    """Test suite for SequentialFileIdMapper."""
+
+    def test_create_mappings_basic(self):
+        """Test basic ID mapping creation."""
+        mapper = SequentialFileIdMapper()
+        file_paths = [
+            "/path/to/file1.txt",
+            "/path/to/file2.txt",
+            "/path/to/file3.txt",
+        ]
+
+        id_to_path = mapper.create_mappings(file_paths)
+
+        assert len(id_to_path) == 3
+        assert id_to_path["A001"] == "/path/to/file1.txt"
+        assert id_to_path["A002"] == "/path/to/file2.txt"
+        assert id_to_path["A003"] == "/path/to/file3.txt"
+
+    def test_create_mappings_with_double_space_filename(self):
+        """Test mapping creation with filenames containing double spaces (Issue #112)."""
+        mapper = SequentialFileIdMapper()
+        file_paths = [
+            "/Users/leo/Desktop/Ch7  Cluster analysis.pdf",  # Double space
+            "/Users/leo/Desktop/Ch8 Regression.pdf",  # Single space
+        ]
+
+        id_to_path = mapper.create_mappings(file_paths)
+
+        assert len(id_to_path) == 2
+        assert id_to_path["A001"] == "/Users/leo/Desktop/Ch7  Cluster analysis.pdf"
+        assert id_to_path["A002"] == "/Users/leo/Desktop/Ch8 Regression.pdf"
+
+    def test_get_path(self):
+        """Test retrieving path by file ID."""
+        mapper = SequentialFileIdMapper()
+        file_paths = ["/path/file1.txt", "/path/file2.txt"]
+        mapper.create_mappings(file_paths)
+
+        assert mapper.get_path("A001") == "/path/file1.txt"
+        assert mapper.get_path("A002") == "/path/file2.txt"
+        assert mapper.get_path("A999") is None
+
+    def test_get_id(self):
+        """Test retrieving file ID by path."""
+        mapper = SequentialFileIdMapper()
+        file_paths = ["/path/file1.txt", "/path/file2.txt"]
+        mapper.create_mappings(file_paths)
+
+        assert mapper.get_id("/path/file1.txt") == "A001"
+        assert mapper.get_id("/path/file2.txt") == "A002"
+        assert mapper.get_id("/nonexistent/path.txt") is None
+
+    def test_get_all_mappings(self):
+        """Test retrieving all mappings."""
+        mapper = SequentialFileIdMapper()
+        file_paths = ["/path/file1.txt", "/path/file2.txt"]
+        mapper.create_mappings(file_paths)
+
+        all_mappings = mapper.get_all_mappings()
+
+        assert len(all_mappings) == 2
+        assert all_mappings["A001"] == "/path/file1.txt"
+        assert all_mappings["A002"] == "/path/file2.txt"
+
+    def test_reset(self):
+        """Test resetting the mapper."""
+        mapper = SequentialFileIdMapper()
+        file_paths = ["/path/file1.txt"]
+        mapper.create_mappings(file_paths)
+
+        assert len(mapper.get_all_mappings()) == 1
+
+        mapper.reset()
+
+        assert len(mapper.get_all_mappings()) == 0
+        assert mapper.get_id("/path/file1.txt") is None
+
+    def test_reset_resets_counter(self):
+        """Test that reset resets the counter for new ID generation."""
+        mapper = SequentialFileIdMapper()
+
+        # Create first batch
+        mapper.create_mappings(["/path/file1.txt"])
+        assert "A001" in mapper.get_all_mappings()
+
+        # Reset and create second batch
+        mapper.reset()
+        mapper.create_mappings(["/path/file2.txt"])
+
+        # Should start from A001 again
+        assert "A001" in mapper.get_all_mappings()
+        assert mapper.get_path("A001") == "/path/file2.txt"
+
+    def test_custom_prefix(self):
+        """Test creating mapper with custom prefix."""
+        mapper = SequentialFileIdMapper(prefix="B")
+        file_paths = ["/path/file1.txt", "/path/file2.txt"]
+        mapper.create_mappings(file_paths)
+
+        assert "B001" in mapper.get_all_mappings()
+        assert "B002" in mapper.get_all_mappings()
+
+    def test_custom_id_width(self):
+        """Test creating mapper with custom ID width."""
+        mapper = SequentialFileIdMapper(id_width=4)
+        file_paths = ["/path/file1.txt"]
+        mapper.create_mappings(file_paths)
+
+        assert "A0001" in mapper.get_all_mappings()
+
+    def test_create_mappings_empty_list_raises_error(self):
+        """Test that empty file list raises ValueError."""
+        mapper = SequentialFileIdMapper()
+
+        with pytest.raises(ValueError, match="file_paths cannot be empty"):
+            mapper.create_mappings([])
+
+    def test_create_mappings_duplicate_paths_raises_error(self):
+        """Test that duplicate paths raise ValueError."""
+        mapper = SequentialFileIdMapper()
+        file_paths = [
+            "/path/file1.txt",
+            "/path/file2.txt",
+            "/path/file1.txt",  # Duplicate
+        ]
+
+        with pytest.raises(ValueError, match="duplicate entries"):
+            mapper.create_mappings(file_paths)
+
+    def test_invalid_prefix_raises_error(self):
+        """Test that invalid prefix raises ValueError."""
+        with pytest.raises(ValueError, match="Prefix must be a single letter"):
+            SequentialFileIdMapper(prefix="AB")
+
+        with pytest.raises(ValueError, match="Prefix must be a single letter"):
+            SequentialFileIdMapper(prefix="1")
+
+    def test_invalid_id_width_raises_error(self):
+        """Test that invalid ID width raises ValueError."""
+        with pytest.raises(ValueError, match="ID width must be >= 1"):
+            SequentialFileIdMapper(id_width=0)
+
+        with pytest.raises(ValueError, match="ID width must be >= 1"):
+            SequentialFileIdMapper(id_width=-1)
+
+    def test_counter_exceeds_maximum_raises_error(self):
+        """Test that counter overflow raises ValueError."""
+        mapper = SequentialFileIdMapper(id_width=1)  # Max 9 IDs
+
+        # Create 9 mappings (should work)
+        paths = [f"/path/file{i}.txt" for i in range(1, 10)]
+        mapper.create_mappings(paths)
+
+        # 10th mapping should fail
+        with pytest.raises(ValueError, match="Counter exceeded maximum value"):
+            mapper.create_mappings(["/path/file10.txt"])
+
+    def test_bidirectional_mapping_consistency(self):
+        """Test that bidirectional mapping is consistent."""
+        mapper = SequentialFileIdMapper()
+        file_paths = [
+            "/path/file1.txt",
+            "/path/file2.txt",
+            "/path/file3.txt",
+        ]
+        mapper.create_mappings(file_paths)
+
+        # Test round-trip consistency
+        for path in file_paths:
+            file_id = mapper.get_id(path)
+            retrieved_path = mapper.get_path(file_id)
+            assert retrieved_path == path
+
+    def test_windows_path_with_double_spaces(self):
+        """Test Windows paths with double spaces (Issue #112)."""
+        mapper = SequentialFileIdMapper()
+        file_paths = [
+            r"C:\Users\leo\Desktop\Ch7  Cluster analysis.pdf",
+            r"C:\Users\leo\Desktop\Ch8 Regression.pdf",
+        ]
+        mapper.create_mappings(file_paths)
+
+        assert mapper.get_id(r"C:\Users\leo\Desktop\Ch7  Cluster analysis.pdf") == "A001"
+        assert mapper.get_path("A001") == r"C:\Users\leo\Desktop\Ch7  Cluster analysis.pdf"
+
+    def test_multiple_special_whitespace_characters(self):
+        """Test paths with various whitespace patterns."""
+        mapper = SequentialFileIdMapper()
+        file_paths = [
+            "/path/file  with  multiple  spaces.txt",
+            "/path/file with\ttab.txt",  # Tab character
+            "/path/normal file.txt",
+        ]
+        mapper.create_mappings(file_paths)
+
+        # All should be mapped correctly
+        assert len(mapper.get_all_mappings()) == 3
+        assert mapper.get_id("/path/file  with  multiple  spaces.txt") == "A001"
+        assert mapper.get_id("/path/file with\ttab.txt") == "A002"
+        assert mapper.get_id("/path/normal file.txt") == "A003"
+
+
+class TestSequentialFileIdMapperSOLIDPrinciples:
+    """Test suite verifying SOLID principles compliance."""
+
+    def test_single_responsibility_principle(self):
+        """Verify SRP: Mapper only handles ID generation and mapping."""
+        mapper = SequentialFileIdMapper()
+
+        # Mapper should ONLY provide ID mapping functionality
+        # It should NOT:
+        # - Parse files
+        # - Validate file existence
+        # - Modify file system
+        # - Handle LLM interactions
+
+        # Test only mapping-related methods exist
+        mapping_methods = {
+            "create_mappings",
+            "get_path",
+            "get_id",
+            "get_all_mappings",
+            "reset",
+        }
+
+        public_methods = {name for name in dir(mapper) if not name.startswith("_") and callable(getattr(mapper, name))}
+
+        # All public methods should be mapping-related
+        assert public_methods == mapping_methods
+
+    def test_open_closed_principle(self):
+        """Verify OCP: Can extend via inheritance without modification."""
+        # Example: Custom ID strategy without modifying base class
+
+        class UUIDFileIdMapper(SequentialFileIdMapper):
+            """Custom mapper using different ID strategy."""
+
+            def _generate_next_id(self):
+                import uuid
+
+                return str(uuid.uuid4())[:8]
+
+        # Should work without modifying SequentialFileIdMapper
+        custom_mapper = UUIDFileIdMapper()
+        custom_mapper.create_mappings(["/path/file.txt"])
+
+        # Verify it works
+        assert len(custom_mapper.get_all_mappings()) == 1
+
+    def test_liskov_substitution_principle(self):
+        """Verify LSP: Mapper can be substituted anywhere IFileIdMapper is expected."""
+        from fileorg.llm_classifier.ports.interfaces import IFileIdMapper
+
+        def use_mapper(mapper: IFileIdMapper, paths: list[str]) -> dict:
+            """Function that uses IFileIdMapper interface."""
+            mapper.create_mappings(paths)
+            return mapper.get_all_mappings()
+
+        # SequentialFileIdMapper should be substitutable
+        mapper = SequentialFileIdMapper()
+        result = use_mapper(mapper, ["/path/file.txt"])
+
+        assert len(result) == 1
+        assert isinstance(result, dict)
+
+    def test_interface_segregation_principle(self):
+        """Verify ISP: Interface only defines essential operations."""
+        from fileorg.llm_classifier.ports.interfaces import IFileIdMapper
+
+        # IFileIdMapper should only require essential methods
+        required_methods = {
+            "create_mappings",
+            "get_path",
+            "get_id",
+            "get_all_mappings",
+            "reset",
+        }
+
+        interface_methods = {name for name in dir(IFileIdMapper) if not name.startswith("_") and callable(getattr(IFileIdMapper, name))}
+
+        # Interface should not force implementation of unnecessary methods
+        assert interface_methods == required_methods
+
+    def test_dependency_inversion_principle(self):
+        """Verify DIP: FileClassifier depends on IFileIdMapper abstraction."""
+        import inspect
+
+        from fileorg.llm_classifier.application.file_classifier import FileClassifier
+
+        # FileClassifier should accept IFileIdMapper, not concrete implementation
+        # This is tested by checking the type hint in __init__
+        sig = inspect.signature(FileClassifier.__init__)
+        file_id_mapper_param = sig.parameters.get("file_id_mapper")
+
+        # Should accept Optional[IFileIdMapper]
+        assert file_id_mapper_param is not None
+        # Type hint should reference interface, not concrete class
+        # (This is checked at design time via type annotations)


### PR DESCRIPTION
## Changes

- Added `SequentialFileIdMapper` to perform inference based on file path IDs rather than raw file paths.
- Added tests to ensure the double-space issue does not reoccur.
- Updated the prompt to improve classification accuracy.

## Resolved Screenshot
<img width="215" height="462" alt="未命名" src="https://github.com/user-attachments/assets/cc492d5d-659e-4fdb-8429-2d662827eb7a" />

## Why #112 and #113 Are Resolved Together

Issues #112 and #113 both depend on improved prompt engineering.
Additionally, the rule-based logic required for #112 also relies on the updated prompt and the new interface introduced in this PR.
Therefore, #113 is addressed as part of the work for #112.

## Related Issues

Fixes: #112, #113
