### PR TITLE
fix(mapper): normalize file IDs to handle stripped leading zeros

### DIFF
--- a/fileorg/llm_classifier/adapters/sequential_file_id_mapper.py
+++ b/fileorg/llm_classifier/adapters/sequential_file_id_mapper.py
@@ -116,7 +116,7 @@ class SequentialFileIdMapper(IFileIdMapper):
         Retrieve original file path for a given file ID.
 
         Args:
-            file_id: The file identifier (e.g., "A001")
+            file_id: The file identifier (e.g., "A001" or "A1")
 
         Returns:
             Original file path if found, None otherwise
@@ -126,10 +126,57 @@ class SequentialFileIdMapper(IFileIdMapper):
             >>> mapper.create_mappings(["/path/file.txt"])
             >>> mapper.get_path("A001")
             "/path/file.txt"
+            >>> mapper.get_path("A1")  # Also works (normalized)
+            "/path/file.txt"
             >>> mapper.get_path("A999")
             None
         """
-        return self._id_to_path.get(file_id)
+        # First try exact match
+        if file_id in self._id_to_path:
+            return self._id_to_path[file_id]
+
+        # Try to normalize the ID (handle cases like "A13" -> "A013")
+        normalized_id = self._normalize_id(file_id)
+        if normalized_id and normalized_id in self._id_to_path:
+            return self._id_to_path[normalized_id]
+
+        return None
+
+    def _normalize_id(self, file_id: str) -> Optional[str]:
+        """
+        Normalize a file ID to match the expected format.
+
+        Handles cases where LLM strips leading zeros (e.g., "A13" -> "A013").
+
+        Args:
+            file_id: The file identifier to normalize
+
+        Returns:
+            Normalized file ID or None if format is invalid
+        """
+        if not file_id:
+            return None
+
+        # Extract prefix and number
+        prefix = ""
+        num_str = ""
+
+        for i, char in enumerate(file_id):
+            if char.isalpha():
+                prefix += char
+            else:
+                num_str = file_id[i:]
+                break
+
+        if not prefix or not num_str:
+            return None
+
+        try:
+            num = int(num_str)
+            # Reconstruct with proper zero-padding
+            return f"{prefix.upper()}{num:0{self._id_width}d}"
+        except ValueError:
+            return None
 
     def get_id(self, file_path: str) -> Optional[str]:
         """


### PR DESCRIPTION
## Summary
- fix `ValueError: Original path not found for file ID: A13`
- LLM sometimes strips leading zeros from file IDs (e.g., "A013" → "A13")
- add `_normalize_id()` to convert "A13" back to "A013" format

## Error message
```bash
ValueError: Original path not found for file ID: A13

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\WoS_user\miniconda3\envs\AIFiling\Scripts\fileorg.exe\__main__.py", line 10, in <module>
    sys.exit(main())
  File "C:\Users\WoS_user\Desktop\AI-Filing-System-DEV\fileorg\main.py", line 21, in main
    fileorg.run()
  File "C:\Users\WoS_user\Desktop\AI-Filing-System-DEV\fileorg\app\file_coordinator.py", line 144, in run
    self.run_organize()
  File "C:\Users\WoS_user\Desktop\AI-Filing-System-DEV\fileorg\app\file_coordinator.py", line 353, in run_organize
    classification_output = self.classifier.classify(llm_input)
  File "C:\Users\WoS_user\Desktop\AI-Filing-System-DEV\fileorg\llm_classifier\application\file_classifier.py", line 156, in classify
    path_mappings, stage2_raw = self.classify_by_summaries(summaries, input_data.max_tokens)
  File "C:\Users\WoS_user\Desktop\AI-Filing-System-DEV\fileorg\llm_classifier\application\file_classifier.py", line 412, in classify_by_summaries
    raise RuntimeError(f"Classification failed: {e}") from e
RuntimeError: Classification failed: Original path not found for file ID: A13
```