### PR TITLE
fix(port_generator): correct inverted condition and consistency in path

### DIFF
--- a/fileorg/app/file_coordinator.py
+++ b/fileorg/app/file_coordinator.py
@@ -129,7 +129,7 @@ class FileCoordinator:
             raise RuntimeError(f"Organizer initialization failed: {e}") from e
 
     def _init_report_generator(self):
-        if self.report_generator is None:
+        if self.report_generator is not None:
             return  # Already initialized
         try:
             logger.info("Initializing report generator...")

--- a/fileorg/report_generator/adapters/html_visualizer.py
+++ b/fileorg/report_generator/adapters/html_visualizer.py
@@ -35,7 +35,7 @@ class HtmlReportGenerator(ClassificationReportHtmlPort):
         """
 
         # Default output file name
-        output_path = root_dir / ".backup" / "ClassificationReport.html"
+        output_path = Path(root_dir) / ".backup" / "ClassificationReport.html"
 
         # 自動建立所有不存在的資料夾
         output_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- added `Path(root_dir)` conversion to handle string input
- correct inverted condition in _init_report_generator